### PR TITLE
Rename uart0 to uart_0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,8 @@ jobs:
           git commit -a -m "Add external component"
         working-directory: ${{ env.esphome_directory }}
 
+      - name: Add missing requirements
+        run: pip3 install setuptools wheel
       - name: Set up python environment
         run: VIRTUAL_ENV=false script/setup
         working-directory: ${{ env.esphome_directory }}

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ logger:
   level: DEBUG
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: GPIO4
   rx_pin: GPIO5

--- a/esp32-example-debug.yaml
+++ b/esp32-example-debug.yaml
@@ -4,7 +4,7 @@ logger:
   level: DEBUG
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: ${tx_pin}
     rx_pin: ${rx_pin}

--- a/esp32-example-faker.yaml
+++ b/esp32-example-faker.yaml
@@ -2,7 +2,7 @@
 
 jbd_bms:
   - id: bms0
-    uart_id: uart0
+    uart_id: uart_0
     update_interval: 2s
     rx_timeout: ${rx_timeout}
     enable_fake_traffic: true

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -42,7 +42,7 @@ mqtt:
 # api:
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: ${tx_pin}
     rx_pin: ${rx_pin}

--- a/esp8266-example-debug.yaml
+++ b/esp8266-example-debug.yaml
@@ -4,7 +4,7 @@ logger:
   level: DEBUG
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: ${tx_pin}
     rx_pin: ${rx_pin}

--- a/esp8266-example-faker.yaml
+++ b/esp8266-example-faker.yaml
@@ -2,7 +2,7 @@
 
 jbd_bms:
   - id: bms0
-    uart_id: uart0
+    uart_id: uart_0
     update_interval: 2s
     rx_timeout: ${rx_timeout}
     enable_fake_traffic: true

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -40,7 +40,7 @@ mqtt:
 # api:
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: ${tx_pin}
     rx_pin: ${rx_pin}

--- a/tests/esp8266-dummy-receiver.yaml
+++ b/tests/esp8266-dummy-receiver.yaml
@@ -22,7 +22,7 @@ api:
   reboot_timeout: 0s
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}

--- a/tests/esp8266-query-data.yaml
+++ b/tests/esp8266-query-data.yaml
@@ -22,7 +22,7 @@ api:
   reboot_timeout: 0s
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}


### PR DESCRIPTION
This change is required by ESPHome 2023.4.0

See https://github.com/esphome/esphome/pull/4446