### PR TITLE
Add threshold to avoid oscillation

### DIFF
--- a/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
+++ b/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
@@ -76,7 +76,7 @@ sensor:
                 - switch.is_off: charging
                 - sensor.in_range:
                     id: state_of_charge
-                    below: 80.0
+                    below: 79.0
             then:
               - switch.turn_on: charging
 


### PR DESCRIPTION
Hi men, i have test your solution, it's working almost perfectly ;)

Go down to 79% to enable charge to resolve this problem :
When battery is 80% charge, the esp enable, stop, enable, stop in loop the charge switch
![image](https://github.com/syssi/esphome-jbd-bms/assets/17613028/241621ce-19d0-49a6-9717-f7104a0e99c5)
![image](https://github.com/syssi/esphome-jbd-bms/assets/17613028/0098c43c-2fe3-4dab-bee8-5ef86eb90b9f)
