### PR TITLE
Add Alternate UP protocol

### DIFF
--- a/components/jbd_bms/__init__.py
+++ b/components/jbd_bms/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_UART_ID
 
 CODEOWNERS = ["@syssi"]
 
@@ -11,9 +11,15 @@ MULTI_CONF = True
 
 CONF_JBD_BMS_ID = "jbd_bms_id"
 CONF_RX_TIMEOUT = "rx_timeout"
+CONF_PROTOCOL = "protocol"
+CONF_ADDRESS = "address"
+CONF_MASTER = "master"
 
 jbd_bms_ns = cg.esphome_ns.namespace("jbd_bms")
 JbdBms = jbd_bms_ns.class_("JbdBms", cg.PollingComponent, uart.UARTDevice)
+JbdBmsUP = jbd_bms_ns.class_("JbdBmsUP", JbdBms)
+
+MASTERS = {}
 
 JBD_BMS_COMPONENT_SCHEMA = cv.Schema(
     {
@@ -28,6 +34,14 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_RX_TIMEOUT, default="150ms"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_PROTOCOL, default='JBD',
+            ): cv.enum({
+                "JBD": 0,
+                "UP": 1,
+            }, upper=True),
+            cv.Optional(CONF_MASTER): cv.use_id(JbdBms),
+            cv.Optional(CONF_ADDRESS, default = 1): cv.int_range(0, 16),
         }
     )
     .extend(cv.polling_component_schema("2s"))
@@ -36,8 +50,16 @@ CONFIG_SCHEMA = (
 
 
 async def to_code(config):
+    if config[CONF_PROTOCOL] == 'UP':
+        config[CONF_ID].type = JbdBmsUP
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
     cg.add(var.set_rx_timeout(config[CONF_RX_TIMEOUT]))
+    if config[CONF_PROTOCOL] == 'UP':
+        if config[CONF_UART_ID] not in MASTERS:
+            MASTERS[config[CONF_UART_ID]] = var
+            cg.add(var.set_is_master(True))
+        cg.add(var.set_battery_address(config[CONF_ADDRESS]))
+        cg.add(MASTERS[config[CONF_UART_ID]].add_battery(var))

--- a/components/jbd_bms/binary_sensor.py
+++ b/components/jbd_bms/binary_sensor.py
@@ -12,16 +12,25 @@ CODEOWNERS = ["@syssi"]
 
 CONF_BALANCING = "balancing"
 CONF_ONLINE_STATUS = "online_status"
+CONF_PRECHARGING = "precharging"
+CONF_FAN = "fan"
+CONF_HEAT = "heat"
 
 ICON_CHARGING = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
 ICON_BALANCING = "mdi:battery-heart-variant"
+ICON_FAN = "mdi:fan"
+ICON_HEAT = "mdi:radiator"
 
 BINARY_SENSORS = [
     CONF_CHARGING,
     CONF_DISCHARGING,
     CONF_BALANCING,
     CONF_ONLINE_STATUS,
+    # UP ONLY
+    CONF_PRECHARGING,
+    CONF_HEAT,
+    CONF_FAN,
 ]
 
 CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
@@ -38,6 +47,13 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_ONLINE_STATUS): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_CONNECTIVITY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_PRECHARGING): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_HEAT): binary_sensor.binary_sensor_schema(
+            icon=ICON_HEAT
+        ),
+        cv.Optional(CONF_FAN): binary_sensor.binary_sensor_schema(
+            icon=ICON_FAN
         ),
     }
 )

--- a/components/jbd_bms/binary_sensor.py
+++ b/components/jbd_bms/binary_sensor.py
@@ -49,12 +49,8 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_PRECHARGING): binary_sensor.binary_sensor_schema(),
-        cv.Optional(CONF_HEAT): binary_sensor.binary_sensor_schema(
-            icon=ICON_HEAT
-        ),
-        cv.Optional(CONF_FAN): binary_sensor.binary_sensor_schema(
-            icon=ICON_FAN
-        ),
+        cv.Optional(CONF_HEAT): binary_sensor.binary_sensor_schema(icon=ICON_HEAT),
+        cv.Optional(CONF_FAN): binary_sensor.binary_sensor_schema(icon=ICON_FAN),
     }
 )
 

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -578,7 +578,7 @@ void JbdBms::send_command(uint8_t action, uint8_t function) {
 }
 
 std::string JbdBms::bitmask_to_string_(const char *const messages[], const uint8_t &messages_size,
-                                       const uint16_t &mask) {
+                                       const uint32_t &mask) {
   std::string values = "";
   if (mask) {
     for (int i = 0; i < messages_size; i++) {

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -51,7 +51,7 @@ static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
 void JbdBms::setup() { this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO); }
 
 void JbdBms::loop() {
-  if (! this->is_master_) {
+  if (!this->is_master_) {
     return;
   }
   const uint32_t now = millis();
@@ -66,7 +66,7 @@ void JbdBms::loop() {
   while (this->available()) {
     uint8_t byte;
     this->read_byte(&byte);
-    if (this->parse_jbd_bms_byte_(byte)) {
+    if (this->parse_jbd_bms_byte(byte)) {
       this->last_byte_ = now;
     } else {
       ESP_LOGVV(TAG, "Buffer cleared due to reset: %s",
@@ -81,7 +81,7 @@ void JbdBms::update() {
   this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
 }
 
-bool JbdBms::parse_jbd_bms_byte_(uint8_t byte) {
+bool JbdBms::parse_jbd_bms_byte(uint8_t byte) {
   size_t at = this->rx_buffer_.size();
   this->rx_buffer_.push_back(byte);
   const uint8_t *raw = &this->rx_buffer_[0];

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -1,6 +1,7 @@
 #include "jbd_bms.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "jbd_bms_commands.h"
 
 namespace esphome {
 namespace jbd_bms {
@@ -11,20 +12,6 @@ static const uint8_t MAX_NO_RESPONSE_COUNT = 5;
 
 static const uint8_t JBD_PKT_START = 0xDD;
 static const uint8_t JBD_PKT_END = 0x77;
-static const uint8_t JBD_CMD_READ = 0xA5;
-static const uint8_t JBD_CMD_WRITE = 0x5A;
-
-static const uint8_t JBD_CMD_HWINFO = 0x03;
-static const uint8_t JBD_CMD_CELLINFO = 0x04;
-static const uint8_t JBD_CMD_HWVER = 0x05;
-
-static const uint8_t JBD_CMD_ENTER_FACTORY = 0x00;
-static const uint8_t JBD_CMD_EXIT_FACTORY = 0x01;
-static const uint8_t JBD_CMD_FORCE_SOC_RESET = 0x0A;
-static const uint8_t JBD_CMD_ERROR_COUNTS = 0xAA;
-static const uint8_t JBD_CMD_CAP_REM = 0xE0;   // Set remaining capacity
-static const uint8_t JBD_CMD_MOS = 0xE1;       // Set charging/discharging bitmask
-static const uint8_t JBD_CMD_BALANCER = 0xE2;  // Enable/disable balancer
 
 static const uint8_t JBD_MOS_CHARGE = 0x01;
 static const uint8_t JBD_MOS_DISCHARGE = 0x02;
@@ -64,6 +51,9 @@ static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
 void JbdBms::setup() { this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO); }
 
 void JbdBms::loop() {
+  if (! this->is_master_) {
+    return;
+  }
   const uint32_t now = millis();
 
   if (now - this->last_byte_ > this->rx_timeout_) {
@@ -416,7 +406,6 @@ void JbdBms::publish_device_unavailable_() {
 void JbdBms::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "JbdBms:");
   ESP_LOGCONFIG(TAG, "  RX timeout: %d ms", this->rx_timeout_);
-
   LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -146,10 +146,11 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
     device_model_text_sensor_ = device_model_text_sensor;
   }
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
-  void send_command(uint8_t action, uint8_t function);
-  bool write_register(uint8_t address, uint16_t value);
+
+  virtual void send_command(uint8_t action, uint8_t function);
+  virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
-  void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
+  virtual void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
 
  protected:
   binary_sensor::BinarySensor *balancing_binary_sensor_;
@@ -220,6 +221,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   std::vector<uint8_t> rx_buffer_;
   uint32_t last_byte_{0};
   uint16_t rx_timeout_{150};
+  bool is_master_{true};
   uint8_t no_response_count_{0};
   uint8_t mosfet_status_{255};
 
@@ -227,7 +229,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void on_error_counts_data_(const std::vector<uint8_t> &data);
   void on_hardware_info_data_(const std::vector<uint8_t> &data);
   void on_hardware_version_data_(const std::vector<uint8_t> &data);
-  bool parse_jbd_bms_byte_(uint8_t byte);
+  virtual bool parse_jbd_bms_byte_(uint8_t byte);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(switch_::Switch *obj, const bool &state);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -237,7 +237,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void publish_device_unavailable_();
   void reset_online_status_tracker_();
   void track_online_status_();
-  std::string bitmask_to_string_(const char *const messages[], const uint8_t &messages_size, const uint16_t &mask);
+  std::string bitmask_to_string_(const char *const messages[], const uint8_t &messages_size, const uint32_t &mask);
 
   uint16_t chksum_(const uint8_t data[], const uint16_t len) {
     uint16_t checksum = 0x00;

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -229,7 +229,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void on_error_counts_data_(const std::vector<uint8_t> &data);
   void on_hardware_info_data_(const std::vector<uint8_t> &data);
   void on_hardware_version_data_(const std::vector<uint8_t> &data);
-  virtual bool parse_jbd_bms_byte_(uint8_t byte);
+  virtual bool parse_jbd_bms_byte(uint8_t byte);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(switch_::Switch *obj, const bool &state);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -11,6 +11,8 @@
 namespace esphome {
 namespace jbd_bms {
 
+enum mos_state_e { ENABLE = 0x03, DISABLE = 0x00 };
+
 class JbdBms : public uart::UARTDevice, public PollingComponent {
  public:
   void loop() override;
@@ -150,7 +152,9 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   virtual void send_command(uint8_t action, uint8_t function);
   virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
+  bool change_mosfet_status(mos_state_e state);
   virtual void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
+  virtual bool is_master() { return true; }
 
  protected:
   binary_sensor::BinarySensor *balancing_binary_sensor_;
@@ -221,7 +225,6 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   std::vector<uint8_t> rx_buffer_;
   uint32_t last_byte_{0};
   uint16_t rx_timeout_{150};
-  bool is_master_{true};
   uint8_t no_response_count_{0};
   uint8_t mosfet_status_{255};
 

--- a/components/jbd_bms/jbd_bms_commands.h
+++ b/components/jbd_bms/jbd_bms_commands.h
@@ -1,0 +1,17 @@
+# pragma once
+
+static const uint8_t JBD_CMD_READ = 0xA5;
+static const uint8_t JBD_CMD_WRITE = 0x5A;
+
+static const uint8_t JBD_CMD_HWINFO = 0x03;
+static const uint8_t JBD_CMD_CELLINFO = 0x04;
+static const uint8_t JBD_CMD_HWVER = 0x05;
+
+static const uint8_t JBD_CMD_ENTER_FACTORY = 0x00;
+static const uint8_t JBD_CMD_EXIT_FACTORY = 0x01;
+static const uint8_t JBD_CMD_FORCE_SOC_RESET = 0x0A;
+static const uint8_t JBD_CMD_ERROR_COUNTS = 0xAA;
+static const uint8_t JBD_CMD_CAP_REM = 0xE0;   // Set remaining capacity
+static const uint8_t JBD_CMD_MOS = 0xE1;       // Set charging/discharging bitmask
+static const uint8_t JBD_CMD_BALANCER = 0xE2;  // Enable/disable balancer
+

--- a/components/jbd_bms/jbd_bms_commands.h
+++ b/components/jbd_bms/jbd_bms_commands.h
@@ -1,4 +1,7 @@
-# pragma once
+#pragma once
+
+namespace esphome {
+namespace jbd_bms {
 
 static const uint8_t JBD_CMD_READ = 0xA5;
 static const uint8_t JBD_CMD_WRITE = 0x5A;
@@ -15,3 +18,5 @@ static const uint8_t JBD_CMD_CAP_REM = 0xE0;   // Set remaining capacity
 static const uint8_t JBD_CMD_MOS = 0xE1;       // Set charging/discharging bitmask
 static const uint8_t JBD_CMD_BALANCER = 0xE2;  // Enable/disable balancer
 
+}  // namespace jbd_bms
+}  // namespace esphome

--- a/components/jbd_bms/jbd_bms_up.cpp
+++ b/components/jbd_bms/jbd_bms_up.cpp
@@ -9,15 +9,15 @@ namespace jbd_bms {
 static const char *const TAG = "jbd_bms_up";
 
 enum JBDAddress {
-    JBD_PACK_STATUS = 0x1000,
+  JBD_PACK_STATUS = 0x1000,
 };
 
 enum JBDFunction {
-    JBD_READ_BMS = 0x78,
-    JBD_WRITE_BMS = 0x79,
+  JBD_READ_BMS = 0x78,
+  JBD_WRITE_BMS = 0x79,
 };
 
-bool JbdBmsUP::parse_jbd_bms_byte_(uint8_t byte) {
+bool JbdBmsUP::parse_jbd_bms_byte(uint8_t byte) {
   size_t at = this->rx_buffer_.size();
   this->rx_buffer_.push_back(byte);
   const uint8_t *raw = &this->rx_buffer_[0];
@@ -63,9 +63,8 @@ bool JbdBmsUP::parse_jbd_bms_byte_(uint8_t byte) {
     ESP_LOGW(TAG, "CRC check failed! 0x%04X != 0x%04X", computed_crc, remote_crc);
     return false;
   }
-  uint16_t address = (uint16_t(raw[2]) << 8) | (uint16_t(raw[3]) << 0)
-  ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw, at).c_str());
-
+  uint16_t address =
+      (uint16_t(raw[2]) << 8) | (uint16_t(raw[3]) << 0) ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw, at).c_str());
 
   std::vector<uint8_t> data(this->rx_buffer_.begin() + 8, this->rx_buffer_.begin() + frame_len - 2);
   bool found = false;
@@ -86,138 +85,134 @@ bool JbdBmsUP::parse_jbd_bms_byte_(uint8_t byte) {
   this->rx_buffer_.clear();
   return true;
 }
-    
-void JbdBmsUP::on_jbd_bms_data(const uint8_t &function, const uint16_t &reg_address, const std::vector<uint8_t> &data)
-{
-    this->reset_online_status_tracker_();
-    if (function == JBD_READ_BMS) {
-        switch (reg_address) {
-            case JBD_PACK_STATUS:
-                ESP_LOGVV(TAG, "Got pack status");
-                on_pack_status(data);
-                return;
-        }
+
+void JbdBmsUP::on_jbd_bms_data(const uint8_t &function, const uint16_t &reg_address, const std::vector<uint8_t> &data) {
+  this->reset_online_status_tracker_();
+  if (function == JBD_READ_BMS) {
+    switch (reg_address) {
+      case JBD_PACK_STATUS:
+        ESP_LOGVV(TAG, "Got pack status");
+        on_pack_status_(data);
+        return;
     }
-    ESP_LOGW(TAG, "Unhandled response (function 0x%02X) received: %s", function,
-             format_hex_pretty(&data.front(), data.size()).c_str());
+  }
+  ESP_LOGW(TAG, "Unhandled response (function 0x%02X) received: %s", function,
+           format_hex_pretty(&data.front(), data.size()).c_str());
 }
 
-void JbdBmsUP::on_pack_status(const std::vector<uint8_t> &data) {
-    auto get_16bit = [&](size_t i) -> uint16_t {
-        return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
-    };
-    auto get_32bit = [&](size_t i) -> uint32_t {
-        return (uint32_t(data[i + 0]) << 24) | (uint32_t(data[i + 1]) << 16) | (uint32_t(data[i + 2]) << 8) | (uint32_t(data[i + 3]) << 0);
-    };
+void JbdBmsUP::on_pack_status_(const std::vector<uint8_t> &data) {
+  auto get_16bit = [&](size_t i) -> uint16_t { return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0); };
+  auto get_32bit = [&](size_t i) -> uint32_t {
+    return (uint32_t(data[i + 0]) << 24) | (uint32_t(data[i + 1]) << 16) | (uint32_t(data[i + 2]) << 8) |
+           (uint32_t(data[i + 3]) << 0);
+  };
 
-    float total_voltage = (float)get_16bit(0) * 0.01;
-    float current = ((float)get_32bit(4) - 300000.0) * 0.01;
-    float power = total_voltage * current;
-    this->publish_state_(this->total_voltage_sensor_, total_voltage);
-    this->publish_state_(this->current_sensor_, current);
-    this->publish_state_(this->power_sensor_, power);
-    this->publish_state_(this->charging_power_sensor_, std::max(0.0f, power));               // 500W vs 0W -> 500W
-    this->publish_state_(this->discharging_power_sensor_, std::abs(std::min(0.0f, power)));  // -500W vs 0W -> 500W
+  float total_voltage = (float) get_16bit(0) * 0.01;
+  float current = ((float) get_32bit(4) - 300000.0) * 0.01;
+  float power = total_voltage * current;
+  this->publish_state_(this->total_voltage_sensor_, total_voltage);
+  this->publish_state_(this->current_sensor_, current);
+  this->publish_state_(this->power_sensor_, power);
+  this->publish_state_(this->charging_power_sensor_, std::max(0.0f, power));               // 500W vs 0W -> 500W
+  this->publish_state_(this->discharging_power_sensor_, std::abs(std::min(0.0f, power)));  // -500W vs 0W -> 500W
 
-    this->publish_state_(this->state_of_charge_sensor_, (float)get_16bit(8) * 0.01);
-    this->publish_state_(this->capacity_remaining_sensor_, (float)get_16bit(10) * 0.01);
-    this->publish_state_(this->nominal_capacity_sensor_, (float)get_16bit(12) * 0.01);
-    this->publish_state_(this->mosfet_temperature_sensor_, ((float)get_16bit(16) - 500) * 0.1);
-    this->publish_state_(this->ambient_temperature_sensor_, ((float)get_16bit(18) - 500) * 0.1);
-    this->publish_state_(this->state_of_health_sensor_, (float)get_16bit(22));
+  this->publish_state_(this->state_of_charge_sensor_, (float) get_16bit(8) * 0.01);
+  this->publish_state_(this->capacity_remaining_sensor_, (float) get_16bit(10) * 0.01);
+  this->publish_state_(this->nominal_capacity_sensor_, (float) get_16bit(12) * 0.01);
+  this->publish_state_(this->mosfet_temperature_sensor_, ((float) get_16bit(16) - 500) * 0.1);
+  this->publish_state_(this->ambient_temperature_sensor_, ((float) get_16bit(18) - 500) * 0.1);
+  this->publish_state_(this->state_of_health_sensor_, (float) get_16bit(22));
 
-    this->mosfet_status_ = get_16bit(32);
-    auto mos_states = this->mosfet_status_;
-    this->publish_state_(discharging_binary_sensor_, mos_states & 0x01);
-    this->publish_state_(charging_binary_sensor_, mos_states & 0x02);
-    this->publish_state_(precharging_binary_sensor_, mos_states & 0x04);
-    this->publish_state_(heat_binary_sensor_, mos_states & 0x08);
-    this->publish_state_(fan_binary_sensor_, mos_states & 0x10);
+  this->mosfet_status_ = get_16bit(32);
+  auto mos_states = this->mosfet_status_;
+  this->publish_state_(discharging_binary_sensor_, mos_states & 0x01);
+  this->publish_state_(charging_binary_sensor_, mos_states & 0x02);
+  this->publish_state_(precharging_binary_sensor_, mos_states & 0x04);
+  this->publish_state_(heat_binary_sensor_, mos_states & 0x08);
+  this->publish_state_(fan_binary_sensor_, mos_states & 0x10);
 
-    this->publish_state_(this->charging_cycles_sensor_, get_16bit(36));
+  this->publish_state_(this->charging_cycles_sensor_, get_16bit(36));
 
-    this->publish_state_(this->max_voltage_cell_sensor_, get_16bit(38));
-    float max_cell_voltage = (float)get_16bit(40) * 0.001;
-    this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
-    this->publish_state_(this->min_voltage_cell_sensor_, get_16bit(42));
-    float min_cell_voltage = (float)get_16bit(44) * 0.001;
-    this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
-    this->publish_state_(this->average_cell_voltage_sensor_, (float)get_16bit(46) * 0.001);
-    this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
-    int num_cells = get_16bit(66);
-    this->publish_state_(this->battery_strings_sensor_, num_cells);
-    for (int i = 0; i < std::min(num_cells, 32) ; i++) {
-        this->publish_state_(this->cells_[i].cell_voltage_sensor_, (float)get_16bit(68+2*i) * 0.001);
-    }
-    int pos = 68 + 2 * num_cells;
-    int num_temperature_sensors = get_16bit(pos);
-    pos += 2;
-    for (int i = 0; i < std::min(num_temperature_sensors, 6) ; i++) {
-        this->publish_state_(this->temperatures_[i].temperature_sensor_,
-                             (float)((uint32_t)get_16bit(pos+2*i) - 500) * 0.001);
-    }
-    pos += 2*num_temperature_sensors;
-    pos += 6;
-    this->publish_state_(device_model_text_sensor_, std::string(data.begin() + pos, data.begin() + pos + 30));
+  this->publish_state_(this->max_voltage_cell_sensor_, get_16bit(38));
+  float max_cell_voltage = (float) get_16bit(40) * 0.001;
+  this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
+  this->publish_state_(this->min_voltage_cell_sensor_, get_16bit(42));
+  float min_cell_voltage = (float) get_16bit(44) * 0.001;
+  this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
+  this->publish_state_(this->average_cell_voltage_sensor_, (float) get_16bit(46) * 0.001);
+  this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
+  int num_cells = get_16bit(66);
+  this->publish_state_(this->battery_strings_sensor_, num_cells);
+  for (int i = 0; i < std::min(num_cells, 32); i++) {
+    this->publish_state_(this->cells_[i].cell_voltage_sensor_, (float) get_16bit(68 + 2 * i) * 0.001);
+  }
+  int pos = 68 + 2 * num_cells;
+  int num_temperature_sensors = get_16bit(pos);
+  pos += 2;
+  for (int i = 0; i < std::min(num_temperature_sensors, 6); i++) {
+    this->publish_state_(this->temperatures_[i].temperature_sensor_,
+                         (float) ((uint32_t) get_16bit(pos + 2 * i) - 500) * 0.001);
+  }
+  pos += 2 * num_temperature_sensors;
+  pos += 6;
+  this->publish_state_(device_model_text_sensor_, std::string(data.begin() + pos, data.begin() + pos + 30));
 }
 
 bool JbdBmsUP::change_mosfet_status(uint8_t address, uint8_t bitmask, bool state) {
-    if (this->mosfet_status_ == 255) {
-        ESP_LOGE(TAG, "Unable to change the Mosfet status because it's unknown");
-        return false;
-    }
+  if (this->mosfet_status_ == 255) {
+    ESP_LOGE(TAG, "Unable to change the Mosfet status because it's unknown");
+    return false;
+  }
 
-    uint16_t value = (this->mosfet_status_ & (~(1 << bitmask))) | ((uint8_t) state << bitmask);
+  uint16_t value = (this->mosfet_status_ & (~(1 << bitmask))) | ((uint8_t) state << bitmask);
 
-    std::vector<uint8_t> data(6);
-    data[0] = 0x11;
-    data[1] = 'J';
-    data[2] = 'B';
-    data[3] = 'D';
-    data[4] = value >> 8;
-    data[5] = value & 0xff;
-    send_command(JBD_WRITE_BMS, 0x2902, 0x2904, data);
-    return true;
+  std::vector<uint8_t> data(6);
+  data[0] = 0x11;
+  data[1] = 'J';
+  data[2] = 'B';
+  data[3] = 'D';
+  data[4] = value >> 8;
+  data[5] = value & 0xff;
+  send_command(JBD_WRITE_BMS, 0x2902, 0x2904, data);
+  return true;
 }
 
-void JbdBmsUP::send_command(uint8_t action, uint8_t function)
-{
-    std::vector<uint8_t>data;
-    if (action == JBD_CMD_READ) {
-        if (function == JBD_CMD_HWINFO) {
-            send_command(0x78, 0x1000, 0x10a0, data);
-            return;
-        }
+void JbdBmsUP::send_command(uint8_t action, uint8_t function) {
+  std::vector<uint8_t> data;
+  if (action == JBD_CMD_READ) {
+    if (function == JBD_CMD_HWINFO) {
+      send_command(0x78, 0x1000, 0x10a0, data);
+      return;
     }
-    ESP_LOGW(TAG, "Invallid command: %02x, %02x", action, function);
-
+  }
+  ESP_LOGW(TAG, "Invallid command: %02x, %02x", action, function);
 }
 
-void JbdBmsUP::send_command(uint8_t function, uint16_t start_address, uint16_t end_address, const std::vector<uint8_t> &data) {
-    uint8_t header[256];
-    uint8_t crc_arr[2];
-    if (data.size() > 246) {
-        ESP_LOGE(TAG, "Data length %d > 246.  Cannot send", data.size());
-        return;
-    }
-    header[0] = address_;
-    header[1] = function;
-    header[2] = start_address >> 8;
-    header[3] = start_address & 0xff;
-    header[4] = end_address >> 8;
-    header[5] = end_address & 0xff;
-    header[6] = data.size() >> 8;
-    header[7] = data.size() & 0xff;
-    if (data.size()) {
-        memcpy(header+8, data.data(), data.size());
-    }
-    auto crc = crc16(header, data.size() + 8);
-    header[8 + data.size()] = crc & 0xff;
-    header[9 + data.size()] = crc >> 8;
-    ESP_LOGVV(TAG, "Send command: %s",
-              format_hex_pretty(header, 10 + data.size()).c_str());
-    this->write_array(header, 10 + data.size());
-    this->flush();
+void JbdBmsUP::send_command(uint8_t function, uint16_t start_address, uint16_t end_address,
+                            const std::vector<uint8_t> &data) {
+  uint8_t header[256];
+  uint8_t crc_arr[2];
+  if (data.size() > 246) {
+    ESP_LOGE(TAG, "Data length %d > 246.  Cannot send", data.size());
+    return;
+  }
+  header[0] = address_;
+  header[1] = function;
+  header[2] = start_address >> 8;
+  header[3] = start_address & 0xff;
+  header[4] = end_address >> 8;
+  header[5] = end_address & 0xff;
+  header[6] = data.size() >> 8;
+  header[7] = data.size() & 0xff;
+  if (data.size()) {
+    memcpy(header + 8, data.data(), data.size());
+  }
+  auto crc = crc16(header, data.size() + 8);
+  header[8 + data.size()] = crc & 0xff;
+  header[9 + data.size()] = crc >> 8;
+  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(header, 10 + data.size()).c_str());
+  this->write_array(header, 10 + data.size());
+  this->flush();
 }
 
 }  // namespace jbd_bms

--- a/components/jbd_bms/jbd_bms_up.cpp
+++ b/components/jbd_bms/jbd_bms_up.cpp
@@ -1,0 +1,224 @@
+#include "jbd_bms_up.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "jbd_bms_commands.h"
+
+namespace esphome {
+namespace jbd_bms {
+
+static const char *const TAG = "jbd_bms_up";
+
+enum JBDAddress {
+    JBD_PACK_STATUS = 0x1000,
+};
+
+enum JBDFunction {
+    JBD_READ_BMS = 0x78,
+    JBD_WRITE_BMS = 0x79,
+};
+
+bool JbdBmsUP::parse_jbd_bms_byte_(uint8_t byte) {
+  size_t at = this->rx_buffer_.size();
+  this->rx_buffer_.push_back(byte);
+  const uint8_t *raw = &this->rx_buffer_[0];
+
+  // Example response
+  // 0x01 : Bank
+  // 0x78 : Function code
+  // 0x1000 : Start address
+  // 0x10a0 : End address
+  // 0x0000 : Data length
+  // <data> : data
+  // 0x7fb2 : crc16 (LSB 1st)
+
+  if (at == 0) {
+    if (raw[0] > 16) {
+      ESP_LOGW(TAG, "Invalid header: 0x%02X", raw[0]);
+
+      // return false to reset buffer
+      return false;
+    }
+
+    return true;
+  }
+
+  // Byte 1 (Function)
+  // Byte 2,3 (Start addresss)
+  // Byte 4,5 (End addresss)
+  // Byte 6,7 (Length)
+  if (at < 8)
+    return true;
+
+  uint16_t data_len = (raw[6] << 8) | raw[7];
+  uint16_t frame_len = 8 + data_len + 2;
+
+  if (at < frame_len - 1)
+    return true;
+
+  uint8_t bat_address = raw[0];
+  uint8_t function = raw[1];
+  uint16_t computed_crc = crc16(raw, data_len + 8);
+  uint16_t remote_crc = (uint16_t(raw[8 + data_len]) << 0) | (uint16_t(raw[9 + data_len]) << 8);
+  if (computed_crc != remote_crc) {
+    ESP_LOGW(TAG, "CRC check failed! 0x%04X != 0x%04X", computed_crc, remote_crc);
+    return false;
+  }
+  uint16_t address = (uint16_t(raw[2]) << 8) | (uint16_t(raw[3]) << 0)
+  ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw, at).c_str());
+
+
+  std::vector<uint8_t> data(this->rx_buffer_.begin() + 8, this->rx_buffer_.begin() + frame_len - 2);
+  bool found = false;
+  for (auto *battery : this->batteries_) {
+    if (battery->address() != bat_address) {
+      continue;
+    }
+    found = true;
+    battery->on_jbd_bms_data(function, address, data);
+    break;
+  }
+  if (!found) {
+    ESP_LOGW(TAG, "Got unknown battery address 0x%02X! ", bat_address);
+  }
+
+  // reset buffer
+  ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse succeeded", at);
+  this->rx_buffer_.clear();
+  return true;
+}
+    
+void JbdBmsUP::on_jbd_bms_data(const uint8_t &function, const uint16_t &reg_address, const std::vector<uint8_t> &data)
+{
+    this->reset_online_status_tracker_();
+    if (function == JBD_READ_BMS) {
+        switch (reg_address) {
+            case JBD_PACK_STATUS:
+                ESP_LOGVV(TAG, "Got pack status");
+                on_pack_status(data);
+                return;
+        }
+    }
+    ESP_LOGW(TAG, "Unhandled response (function 0x%02X) received: %s", function,
+             format_hex_pretty(&data.front(), data.size()).c_str());
+}
+
+void JbdBmsUP::on_pack_status(const std::vector<uint8_t> &data) {
+    auto get_16bit = [&](size_t i) -> uint16_t {
+        return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
+    };
+    auto get_32bit = [&](size_t i) -> uint32_t {
+        return (uint32_t(data[i + 0]) << 24) | (uint32_t(data[i + 1]) << 16) | (uint32_t(data[i + 2]) << 8) | (uint32_t(data[i + 3]) << 0);
+    };
+
+    float total_voltage = (float)get_16bit(0) * 0.01;
+    float current = (float)(get_32bit(4) - 300000) * 0.01;
+    float power = total_voltage * current;
+    this->publish_state_(this->total_voltage_sensor_, total_voltage);
+    this->publish_state_(this->current_sensor_, current);
+    this->publish_state_(this->power_sensor_, power);
+    this->publish_state_(this->charging_power_sensor_, std::max(0.0f, power));               // 500W vs 0W -> 500W
+    this->publish_state_(this->discharging_power_sensor_, std::abs(std::min(0.0f, power)));  // -500W vs 0W -> 500W
+
+    this->publish_state_(this->state_of_charge_sensor_, (float)get_16bit(8) * 0.01);
+    this->publish_state_(this->capacity_remaining_sensor_, (float)get_16bit(10) * 0.01);
+    this->publish_state_(this->nominal_capacity_sensor_, (float)get_16bit(12) * 0.01);
+    this->publish_state_(this->mosfet_temperature_sensor_, ((float)get_16bit(16) - 500) * 0.1);
+    this->publish_state_(this->ambient_temperature_sensor_, ((float)get_16bit(18) - 500) * 0.1);
+    this->publish_state_(this->state_of_health_sensor_, (float)get_16bit(20));
+
+    this->mosfet_status_ = get_16bit(32);
+    auto mos_states = this->mosfet_status_;
+    this->publish_state_(discharging_binary_sensor_, mos_states & 0x01);
+    this->publish_state_(charging_binary_sensor_, mos_states & 0x02);
+    this->publish_state_(precharging_binary_sensor_, mos_states & 0x04);
+    this->publish_state_(heat_binary_sensor_, mos_states & 0x08);
+    this->publish_state_(fan_binary_sensor_, mos_states & 0x10);
+
+    this->publish_state_(this->charging_cycles_sensor_, get_16bit(36));
+
+    this->publish_state_(this->max_voltage_cell_sensor_, get_16bit(38));
+    float max_cell_voltage = (float)get_16bit(40) * 0.001;
+    this->publish_state_(this->max_cell_voltage_sensor_, max_cell_voltage);
+    this->publish_state_(this->min_voltage_cell_sensor_, get_16bit(42));
+    float min_cell_voltage = (float)get_16bit(44) * 0.001;
+    this->publish_state_(this->min_cell_voltage_sensor_, min_cell_voltage);
+    this->publish_state_(this->average_cell_voltage_sensor_, (float)get_16bit(46) * 0.001);
+    this->publish_state_(this->delta_cell_voltage_sensor_, max_cell_voltage - min_cell_voltage);
+    int num_cells = get_16bit(66);
+    this->publish_state_(this->battery_strings_sensor_, num_cells);
+    for (int i = 0; i < std::min(num_cells, 32) ; i++) {
+        this->publish_state_(this->cells_[i].cell_voltage_sensor_, (float)get_16bit(68+2*i) * 0.001);
+    }
+    int pos = 68 + 2 * num_cells;
+    int num_temperature_sensors = get_16bit(pos);
+    pos += 2;
+    for (int i = 0; i < std::min(num_temperature_sensors, 6) ; i++) {
+        this->publish_state_(this->temperatures_[i].temperature_sensor_,
+                             (float)((uint32_t)get_16bit(pos+2*i) - 500) * 0.001);
+    }
+    pos += 2*num_temperature_sensors;
+    pos += 6;
+    this->publish_state_(device_model_text_sensor_, std::string(data.begin() + pos, data.begin() + pos + 30));
+}
+
+bool JbdBmsUP::change_mosfet_status(uint8_t address, uint8_t bitmask, bool state) {
+    if (this->mosfet_status_ == 255) {
+        ESP_LOGE(TAG, "Unable to change the Mosfet status because it's unknown");
+        return false;
+    }
+
+    uint16_t value = (this->mosfet_status_ & (~(1 << bitmask))) | ((uint8_t) state << bitmask);
+
+    std::vector<uint8_t> data(6);
+    data[0] = 0x11;
+    data[1] = 'J';
+    data[2] = 'B';
+    data[3] = 'D';
+    data[4] = value >> 8;
+    data[5] = value & 0xff;
+    send_command(JBD_WRITE_BMS, 0x2902, 0x2904, data);
+    return true;
+}
+
+void JbdBmsUP::send_command(uint8_t action, uint8_t function)
+{
+    std::vector<uint8_t>data;
+    if (action == JBD_CMD_READ) {
+        if (function == JBD_CMD_HWINFO) {
+            send_command(0x78, 0x1000, 0x10a0, data);
+            return;
+        }
+    }
+    ESP_LOGW(TAG, "Invallid command: %02x, %02x", action, function);
+
+}
+
+void JbdBmsUP::send_command(uint8_t function, uint16_t start_address, uint16_t end_address, const std::vector<uint8_t> &data) {
+    uint8_t header[256];
+    uint8_t crc_arr[2];
+    if (data.size() > 246) {
+        ESP_LOGE(TAG, "Data length %d > 246.  Cannot send", data.size());
+        return;
+    }
+    header[0] = address_;
+    header[1] = function;
+    header[2] = start_address >> 8;
+    header[3] = start_address & 0xff;
+    header[4] = end_address >> 8;
+    header[5] = end_address & 0xff;
+    header[6] = data.size() >> 8;
+    header[7] = data.size() & 0xff;
+    if (data.size()) {
+        memcpy(header+8, data.data(), data.size());
+    }
+    auto crc = crc16(header, data.size() + 8);
+    header[8 + data.size()] = crc & 0xff;
+    header[9 + data.size()] = crc >> 8;
+    ESP_LOGVV(TAG, "Send command: %s",
+              format_hex_pretty(header, 10 + data.size()).c_str());
+    this->write_array(header, 10 + data.size());
+    this->flush();
+}
+
+}  // namespace jbd_bms
+}  // namespace esphome

--- a/components/jbd_bms/jbd_bms_up.cpp
+++ b/components/jbd_bms/jbd_bms_up.cpp
@@ -111,7 +111,7 @@ void JbdBmsUP::on_pack_status(const std::vector<uint8_t> &data) {
     };
 
     float total_voltage = (float)get_16bit(0) * 0.01;
-    float current = (float)(get_32bit(4) - 300000) * 0.01;
+    float current = ((float)get_32bit(4) - 300000.0) * 0.01;
     float power = total_voltage * current;
     this->publish_state_(this->total_voltage_sensor_, total_voltage);
     this->publish_state_(this->current_sensor_, current);
@@ -124,7 +124,7 @@ void JbdBmsUP::on_pack_status(const std::vector<uint8_t> &data) {
     this->publish_state_(this->nominal_capacity_sensor_, (float)get_16bit(12) * 0.01);
     this->publish_state_(this->mosfet_temperature_sensor_, ((float)get_16bit(16) - 500) * 0.1);
     this->publish_state_(this->ambient_temperature_sensor_, ((float)get_16bit(18) - 500) * 0.1);
-    this->publish_state_(this->state_of_health_sensor_, (float)get_16bit(20));
+    this->publish_state_(this->state_of_health_sensor_, (float)get_16bit(22));
 
     this->mosfet_status_ = get_16bit(32);
     auto mos_states = this->mosfet_status_;

--- a/components/jbd_bms/jbd_bms_up.h
+++ b/components/jbd_bms/jbd_bms_up.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "jbd_bms.h"
+
+namespace esphome {
+namespace jbd_bms {
+
+class JbdBmsUP : public JbdBms {
+ public:
+  JbdBmsUP() : JbdBms() { is_master_ = false; }
+  bool parse_jbd_bms_byte_(uint8_t byte);
+  bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
+  void send_command(uint8_t action, uint8_t function);
+  void send_command(uint8_t function, uint16_t start_address, uint16_t end_address, const std::vector<uint8_t> &data);
+  bool write_register(uint8_t address, uint16_t value) {return false;}
+  void on_jbd_bms_data(const uint8_t &function, const uint16_t &reg_address, const std::vector<uint8_t> &data);
+  void set_is_master(bool state) {is_master_ = state; }
+  void add_battery(JbdBmsUP* battery) { batteries_.push_back(battery); }
+  void set_battery_address(uint8_t address) {address_ = address; }
+  uint8_t address() { return address_; }
+
+  void set_mosfet_temperature_sensor(sensor::Sensor *mosfet_temperature_sensor) {
+    mosfet_temperature_sensor_ = mosfet_temperature_sensor;
+  }
+  void set_ambient_temperature_sensor(sensor::Sensor *ambient_temperature_sensor) {
+    ambient_temperature_sensor_ = ambient_temperature_sensor;
+  }
+  void set_state_of_health_sensor(sensor::Sensor *state_of_health_sensor) {
+    state_of_health_sensor_ = state_of_health_sensor;
+  }
+  void set_precharging_binary_sensor(binary_sensor::BinarySensor *precharging_binary_sensor) {
+    precharging_binary_sensor_ = precharging_binary_sensor;
+  }
+  void set_fan_binary_sensor(binary_sensor::BinarySensor *fan_binary_sensor) {
+    fan_binary_sensor_ = fan_binary_sensor;
+  }
+  void set_heat_binary_sensor(binary_sensor::BinarySensor *heat_binary_sensor) {
+    heat_binary_sensor_ = heat_binary_sensor;
+  }
+ protected:
+  void on_pack_status(const std::vector<uint8_t> &data);
+
+  std::vector<JbdBmsUP*> batteries_;
+  uint8_t address_{1};
+
+  sensor::Sensor *mosfet_temperature_sensor_{nullptr};
+  sensor::Sensor *ambient_temperature_sensor_{nullptr};
+  sensor::Sensor *state_of_health_sensor_{nullptr};
+
+  binary_sensor::BinarySensor *precharging_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *heat_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *fan_binary_sensor_{nullptr};
+};
+
+}  // namespace jbd_bms
+}  // namespace esphome

--- a/components/jbd_bms/jbd_bms_up.h
+++ b/components/jbd_bms/jbd_bms_up.h
@@ -8,15 +8,15 @@ namespace jbd_bms {
 class JbdBmsUP : public JbdBms {
  public:
   JbdBmsUP() : JbdBms() { is_master_ = false; }
-  bool parse_jbd_bms_byte_(uint8_t byte);
+  bool parse_jbd_bms_byte(uint8_t byte) override;
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
-  void send_command(uint8_t action, uint8_t function);
+  void send_command(uint8_t action, uint8_t function) override;
   void send_command(uint8_t function, uint16_t start_address, uint16_t end_address, const std::vector<uint8_t> &data);
-  bool write_register(uint8_t address, uint16_t value) {return false;}
+  bool write_register(uint8_t address, uint16_t value) override { return false; }
   void on_jbd_bms_data(const uint8_t &function, const uint16_t &reg_address, const std::vector<uint8_t> &data);
-  void set_is_master(bool state) {is_master_ = state; }
-  void add_battery(JbdBmsUP* battery) { batteries_.push_back(battery); }
-  void set_battery_address(uint8_t address) {address_ = address; }
+  void set_is_master(bool state) { is_master_ = state; }
+  void add_battery(JbdBmsUP *battery) { batteries_.push_back(battery); }
+  void set_battery_address(uint8_t address) { address_ = address; }
   uint8_t address() { return address_; }
 
   void set_mosfet_temperature_sensor(sensor::Sensor *mosfet_temperature_sensor) {
@@ -31,16 +31,15 @@ class JbdBmsUP : public JbdBms {
   void set_precharging_binary_sensor(binary_sensor::BinarySensor *precharging_binary_sensor) {
     precharging_binary_sensor_ = precharging_binary_sensor;
   }
-  void set_fan_binary_sensor(binary_sensor::BinarySensor *fan_binary_sensor) {
-    fan_binary_sensor_ = fan_binary_sensor;
-  }
+  void set_fan_binary_sensor(binary_sensor::BinarySensor *fan_binary_sensor) { fan_binary_sensor_ = fan_binary_sensor; }
   void set_heat_binary_sensor(binary_sensor::BinarySensor *heat_binary_sensor) {
     heat_binary_sensor_ = heat_binary_sensor;
   }
- protected:
-  void on_pack_status(const std::vector<uint8_t> &data);
 
-  std::vector<JbdBmsUP*> batteries_;
+ protected:
+  void on_pack_status_(const std::vector<uint8_t> &data);
+
+  std::vector<JbdBmsUP *> batteries_;
   uint8_t address_{1};
 
   sensor::Sensor *mosfet_temperature_sensor_{nullptr};

--- a/components/jbd_bms/jbd_bms_up.h
+++ b/components/jbd_bms/jbd_bms_up.h
@@ -35,6 +35,9 @@ class JbdBmsUP : public JbdBms {
   void set_heat_binary_sensor(binary_sensor::BinarySensor *heat_binary_sensor) {
     heat_binary_sensor_ = heat_binary_sensor;
   }
+  void set_protect_bitmask_sensor(sensor::Sensor *errors_bitmask_sensor) {
+    errors_bitmask_sensor_ = errors_bitmask_sensor;
+  }
 
  protected:
   void on_pack_status_(const std::vector<uint8_t> &data);
@@ -45,10 +48,13 @@ class JbdBmsUP : public JbdBms {
   sensor::Sensor *mosfet_temperature_sensor_{nullptr};
   sensor::Sensor *ambient_temperature_sensor_{nullptr};
   sensor::Sensor *state_of_health_sensor_{nullptr};
+  sensor::Sensor *protect_bitmask_sensor_{nullptr};
 
   binary_sensor::BinarySensor *precharging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *heat_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *fan_binary_sensor_{nullptr};
+
+  text_sensor::TextSensor *protect_text_sensor_{nullptr};
 };
 
 }  // namespace jbd_bms

--- a/components/jbd_bms/sensor.py
+++ b/components/jbd_bms/sensor.py
@@ -98,7 +98,7 @@ CONF_TEMPERATURE_4 = "temperature_4"
 CONF_TEMPERATURE_5 = "temperature_5"
 CONF_TEMPERATURE_6 = "temperature_6"
 
-#UP only
+# UP only
 CONF_MOSFET_TEMPERATURE = "mosfet_temperature"
 CONF_AMBIENT_TEMPERATURE = "ambient_temperature"
 CONF_STATE_OF_HEALTH = "state_of_health"

--- a/components/jbd_bms/sensor.py
+++ b/components/jbd_bms/sensor.py
@@ -98,6 +98,11 @@ CONF_TEMPERATURE_4 = "temperature_4"
 CONF_TEMPERATURE_5 = "temperature_5"
 CONF_TEMPERATURE_6 = "temperature_6"
 
+#UP only
+CONF_MOSFET_TEMPERATURE = "mosfet_temperature"
+CONF_AMBIENT_TEMPERATURE = "ambient_temperature"
+CONF_STATE_OF_HEALTH = "state_of_health"
+
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_BATTERY_STRINGS = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
@@ -193,6 +198,9 @@ SENSORS = [
     CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT,
     CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT,
     CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT,
+    CONF_MOSFET_TEMPERATURE,
+    CONF_AMBIENT_TEMPERATURE,
+    CONF_STATE_OF_HEALTH,
 ]
 
 # pylint: disable=too-many-function-args
@@ -683,6 +691,26 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:counter",
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_EMPTY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_MOSFET_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon=ICON_EMPTY,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_AMBIENT_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon=ICON_EMPTY,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_STATE_OF_HEALTH): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
             state_class=STATE_CLASS_MEASUREMENT,

--- a/esp32-example-up.yaml
+++ b/esp32-example-up.yaml
@@ -1,0 +1,242 @@
+substitutions:
+  name: jbd-bms-uart
+  device_description: "Monitor and control a UP Xiaoxiang Battery Management System (JBD-BMS) via UART"
+  external_components_source: github://syssi/esphome-jbd-bms@main
+  tx_pin: GPIO16
+  rx_pin: GPIO17
+  rx_timeout: 150ms
+
+esphome:
+  name: ${name}
+  comment: ${device_description}
+  min_version: 2024.6.0
+  project:
+    name: "syssi.esphome-jbd-bms"
+    version: 2.2.0
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+packages:
+  # Individual time estimation packages from remote repository
+  remaining_charging_time:
+    url: https://github.com/syssi/esphome-jbd-bms
+    files:
+      - path: packages/remaining_charging_time.yaml
+        vars:
+          sensor_id: bms0_remaining_charging_time
+          sensor_name: "${name} remaining charging time"
+          current_sensor_id: bms0_average_current
+          capacity_remaining_id: bms0_capacity_remaining
+          nominal_capacity_id: bms0_nominal_capacity
+  remaining_discharging_time:
+    url: https://github.com/syssi/esphome-jbd-bms
+    files:
+      - path: packages/remaining_discharging_time.yaml
+        vars:
+          sensor_id: bms0_remaining_discharging_time
+          sensor_name: "${name} remaining discharging time"
+          current_sensor_id: bms0_average_current
+          capacity_remaining_id: bms0_capacity_remaining
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  level: DEBUG
+
+# If you use Home Assistant please remove this `mqtt` section and uncomment the `api` component!
+# The native API has many advantages over MQTT: https://esphome.io/components/api.html#advantages-over-mqtt
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+# api:
+
+uart:
+  - id: uart_0
+    baud_rate: 9600
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+
+jbd_bms:
+  - id: bms0
+    update_interval: 2s
+    rx_timeout: ${rx_timeout}
+    protocol: UP
+    address: 1
+
+button:
+  - platform: jbd_bms
+    jbd_bms_id: bms0
+    retrieve_hardware_version:
+      name: "${name} retrieve hardware version"
+    force_soc_reset:
+      name: "${name} force soc reset"
+
+binary_sensor:
+  - platform: jbd_bms
+    jbd_bms_id: bms0
+    charging:
+      name: "${name} charging"
+    discharging:
+      name: "${name} discharging"
+    precharging:
+      name: "${name} precharging"
+    heat:
+      name: "${name} heat"
+    fan:
+      name: "${name} fan"
+    online_status:
+      name: "${name} online status"
+
+sensor:
+  - platform: jbd_bms
+    jbd_bms_id: bms0
+    battery_strings:
+      name: "${name} battery strings"
+    current:
+      name: "${name} current"
+      id: bms0_current
+    power:
+      name: "${name} power"
+    charging_power:
+      name: "${name} charging power"
+    discharging_power:
+      name: "${name} discharging power"
+    state_of_charge:
+      name: "${name} state of charge"
+    nominal_capacity:
+      name: "${name} nominal capacity"
+      id: bms0_nominal_capacity
+    charging_cycles:
+      name: "${name} charging cycles"
+    capacity_remaining:
+      name: "${name} capacity remaining"
+      id: bms0_capacity_remaining
+    battery_cycle_capacity:
+      name: "${name} battery cycle capacity"
+    total_voltage:
+      name: "${name} total voltage"
+    average_cell_voltage:
+      name: "${name} average cell voltage"
+    delta_cell_voltage:
+      name: "${name} delta cell voltage"
+    min_cell_voltage:
+      name: "${name} min cell voltage"
+    max_cell_voltage:
+      name: "${name} max cell voltage"
+    min_voltage_cell:
+      name: "${name} min voltage cell"
+    max_voltage_cell:
+      name: "${name} max voltage cell"
+    mosfet_temperature:
+      name: "${name} mosfet temperature"
+    ambient_temperature:
+      name: "${name} ambient temperature"
+    state_of_health:
+      name: "${name} state of health"
+    temperature_1:
+      name: "${name} temperature 1"
+    temperature_2:
+      name: "${name} temperature 2"
+    temperature_3:
+      name: "${name} temperature 3"
+    temperature_4:
+      name: "${name} temperature 4"
+    cell_voltage_1:
+      name: "${name} cell voltage 1"
+    cell_voltage_2:
+      name: "${name} cell voltage 2"
+    cell_voltage_3:
+      name: "${name} cell voltage 3"
+    cell_voltage_4:
+      name: "${name} cell voltage 4"
+    cell_voltage_5:
+      name: "${name} cell voltage 5"
+    cell_voltage_6:
+      name: "${name} cell voltage 6"
+    cell_voltage_7:
+      name: "${name} cell voltage 7"
+    cell_voltage_8:
+      name: "${name} cell voltage 8"
+    cell_voltage_9:
+      name: "${name} cell voltage 9"
+    cell_voltage_10:
+      name: "${name} cell voltage 10"
+    cell_voltage_11:
+      name: "${name} cell voltage 11"
+    cell_voltage_12:
+      name: "${name} cell voltage 12"
+    cell_voltage_13:
+      name: "${name} cell voltage 13"
+    cell_voltage_14:
+      name: "${name} cell voltage 14"
+    cell_voltage_15:
+      name: "${name} cell voltage 15"
+    cell_voltage_16:
+      name: "${name} cell voltage 16"
+    operation_status_bitmask:
+      name: "${name} operation status bitmask"
+    errors_bitmask:
+      name: "${name} errors bitmask"
+    software_version:
+      name: "${name} software version"
+
+  # Average current sensor with exponential filtering
+  - platform: copy
+    source_id: bms0_current
+    name: "${name} average current"
+    id: bms0_average_current
+    filters:
+      - exponential_moving_average:
+          alpha: 0.1
+          send_every: 1
+
+text_sensor:
+  - platform: jbd_bms
+    jbd_bms_id: bms0
+    errors:
+      name: "${name} errors"
+    operation_status:
+      name: "${name} operation status"
+    device_model:
+      name: "${name} device model"
+
+select:
+  - platform: jbd_bms
+    jbd_bms_id: bms0
+    read_eeprom_register:
+      name: "${name} read eeprom register"
+      id: read_eeprom_register0
+      optionsmap:
+        0xAA: "Error Counts"
+
+switch:
+  - platform: jbd_bms
+    jbd_bms_id: bms0
+    charging:
+      name: "${name} charging"
+    discharging:
+      name: "${name} discharging"
+
+# Uncomment this section if you want to update the error count sensors periodically
+#
+# interval:
+#   - interval: 30min
+#     then:
+#       - select.set:
+#           id: read_eeprom_register0
+#           option: "Error Counts"


### PR DESCRIPTION
This is an implementation of the alternate JBS modbus protocol for the UP16S010 variants of the JBD BMS.

I've documented the modbus protocol by watching the JDB application `UPseries_BMS-JBD_Tools_V2.7-20230407`.  My analysis can be found here: https://gist.github.com/PhracturedBlue/7ef619594eaa4c27f4ff068b461865b8

Note that this is not the same as the protocol from https://github.com/syssi/esphome-jbd-bms/issues/150
That implements the addressable variant of the JBD protocol.  That is meant for RS485 connections where each battery is connected to the bus.  The modbus protocol works on the RS232, RS485, and CAN ports, and only needs a single connection to the 'master' battery.  This frees up the RS485 port for connection to an inverter.

Testing was done with a pair of Eco-Worthy 48V server rack batteries.

Configuraton is done via adding the following to the jbs_bms configuration:
1) add `protocol: UP`
2) add `address: 1`

These are both optional parameters and will have no impact if not specified.  I've validated these changes are fully backwards-compatible with the existing configuration.