### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/components/jbd_bms/__init__.py
+++ b/components/jbd_bms/__init__.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("2s"))
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/jbd_bms/__init__.py
+++ b/components/jbd_bms/__init__.py
@@ -23,7 +23,8 @@ JBD_BMS_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2025, 11, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JbdBms),

--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -58,7 +58,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("2s"))
+    .extend(cv.polling_component_schema("2s")),
 )
 
 

--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -44,7 +44,8 @@ JBD_BMS_BLE_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2025, 11, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JbdBmsBle),

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.1.0
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-dummy-receiver.yaml
+++ b/tests/esp8266-dummy-receiver.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2025.11.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-data.yaml
+++ b/tests/esp8266-query-data.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2025.11.0
 
 esp8266:
   board: d1_mini

--- a/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
+++ b/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.11.0
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.