### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/jbd_bms/button/__init__.py
+++ b/components/jbd_bms/button/__init__.py
@@ -26,15 +26,15 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_RETRIEVE_HARDWARE_VERSION): button.button_schema(
             JbdButton,
             icon="mdi:numeric",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RETRIEVE_ERROR_COUNTS): button.button_schema(
             JbdButton,
             icon="mdi:counter",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FORCE_SOC_RESET): button.button_schema(
             JbdButton,
             icon="mdi:battery-charging-100",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/jbd_bms/switch/__init__.py
+++ b/components/jbd_bms/switch/__init__.py
@@ -32,15 +32,15 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             JbdSwitch,
             icon=ICON_DISCHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             JbdSwitch,
             icon=ICON_CHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         # cv.Optional(CONF_BALANCER): switch.switch_schema(
         #     JbdSwitch,
         #     icon=ICON_BALANCER,
-        # ).extend(cv.COMPONENT_SCHEMA),
+        # ),
     }
 )
 

--- a/components/jbd_bms_ble/button/__init__.py
+++ b/components/jbd_bms_ble/button/__init__.py
@@ -26,15 +26,15 @@ CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_RETRIEVE_HARDWARE_VERSION): button.button_schema(
             JbdButton,
             icon="mdi:numeric",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RETRIEVE_ERROR_COUNTS): button.button_schema(
             JbdButton,
             icon="mdi:counter",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FORCE_SOC_RESET): button.button_schema(
             JbdButton,
             icon="mdi:battery-charging-100",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/jbd_bms_ble/switch/__init__.py
+++ b/components/jbd_bms_ble/switch/__init__.py
@@ -31,15 +31,15 @@ CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             JbdSwitch,
             icon=ICON_DISCHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             JbdSwitch,
             icon=ICON_CHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         # cv.Optional(CONF_BALANCER): switch.switch_schema(
         #     JbdSwitch,
         #     icon=ICON_BALANCER,
-        # ).extend(cv.COMPONENT_SCHEMA),
+        # ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant