### PR TITLE
Use STATE_CLASS_TOTAL_INCREASING for counter sensors

### DIFF
--- a/components/jbd_bms/sensor.py
+++ b/components/jbd_bms/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
@@ -231,7 +232,7 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
             icon=ICON_CHARGING_CYCLES,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_CAPACITY_REMAINING): sensor.sensor_schema(
             unit_of_measurement=UNIT_AMPERE_HOURS,
@@ -245,7 +246,7 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
             icon=ICON_BATTERY_CYCLE_CAPACITY,
             accuracy_decimals=2,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_TOTAL_VOLTAGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,

--- a/components/jbd_bms_ble/sensor.py
+++ b/components/jbd_bms_ble/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
@@ -231,7 +232,7 @@ CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
             icon=ICON_CHARGING_CYCLES,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_CAPACITY_REMAINING): sensor.sensor_schema(
             unit_of_measurement=UNIT_AMPERE_HOURS,
@@ -245,7 +246,7 @@ CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
             icon=ICON_BATTERY_CYCLE_CAPACITY,
             accuracy_decimals=2,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_TOTAL_VOLTAGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,


### PR DESCRIPTION
`charging_cycles` and `battery_cycle_capacity` are monotonically increasing counters, not instantaneous measurements. Use `STATE_CLASS_TOTAL_INCREASING` so Home Assistant treats them correctly (no negative delta warnings, proper long-term statistics).