### PR TITLE
Explicitly declare ble_client as a component dependency

### DIFF
--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -6,7 +6,7 @@ from esphome.const import CONF_ID, CONF_PASSWORD
 CONF_AUTH_TIMEOUT = "auth_timeout"
 
 CODEOWNERS = ["@syssi"]
-
+DEPENDENCIES = ["ble_client"]
 AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]
 MULTI_CONF = True
 


### PR DESCRIPTION
## Summary

Add \`DEPENDENCIES = ["ble_client"]\` to \`__init__.py\` to explicitly declare the dependency on \`ble_client\`.

All components in ESPHome core that use \`BLE_CLIENT_SCHEMA\` declare this dependency (e.g. \`airthings_wave_base\`, \`bedjet\`, \`pvvx_mithermometer\`). This makes the requirement explicit and consistent with the upstream pattern.