### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jbd-bms"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -28,7 +28,7 @@ packages:
       - path: packages/remaining_charging_time.yaml
         vars:
           sensor_id: bms0_remaining_charging_time
-          sensor_name: "${name} remaining charging time"
+          sensor_name: "remaining charging time"
           current_sensor_id: bms0_average_current
           capacity_remaining_id: bms0_capacity_remaining
           nominal_capacity_id: bms0_nominal_capacity
@@ -38,7 +38,7 @@ packages:
       - path: packages/remaining_discharging_time.yaml
         vars:
           sensor_id: bms0_remaining_discharging_time
-          sensor_name: "${name} remaining discharging time"
+          sensor_name: "remaining discharging time"
           current_sensor_id: bms0_average_current
           capacity_remaining_id: bms0_capacity_remaining
 
@@ -86,175 +86,175 @@ button:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     retrieve_hardware_version:
-      name: "${name} retrieve hardware version"
+      name: "retrieve hardware version"
     retrieve_error_counts:
-      name: "${name} retrieve error counts"
+      name: "retrieve error counts"
     force_soc_reset:
-      name: "${name} force soc reset"
+      name: "force soc reset"
 
 binary_sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     balancing:
-      name: "${name} balancing"
+      name: "balancing"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
     online_status:
-      name: "${name} online status"
+      name: "online status"
 
 sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     battery_strings:
-      name: "${name} battery strings"
+      name: "battery strings"
     current:
-      name: "${name} current"
+      name: "current"
       id: bms0_current
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     nominal_capacity:
-      name: "${name} nominal capacity"
+      name: "nominal capacity"
       id: bms0_nominal_capacity
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
       id: bms0_capacity_remaining
     battery_cycle_capacity:
-      name: "${name} battery cycle capacity"
+      name: "battery cycle capacity"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} temperature 5"
+      name: "temperature 5"
     temperature_6:
-      name: "${name} temperature 6"
+      name: "temperature 6"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     cell_voltage_17:
-      name: "${name} cell voltage 17"
+      name: "cell voltage 17"
     cell_voltage_18:
-      name: "${name} cell voltage 18"
+      name: "cell voltage 18"
     cell_voltage_19:
-      name: "${name} cell voltage 19"
+      name: "cell voltage 19"
     cell_voltage_20:
-      name: "${name} cell voltage 20"
+      name: "cell voltage 20"
     cell_voltage_21:
-      name: "${name} cell voltage 21"
+      name: "cell voltage 21"
     cell_voltage_22:
-      name: "${name} cell voltage 22"
+      name: "cell voltage 22"
     cell_voltage_23:
-      name: "${name} cell voltage 23"
+      name: "cell voltage 23"
     cell_voltage_24:
-      name: "${name} cell voltage 24"
+      name: "cell voltage 24"
     cell_voltage_25:
-      name: "${name} cell voltage 25"
+      name: "cell voltage 25"
     cell_voltage_26:
-      name: "${name} cell voltage 26"
+      name: "cell voltage 26"
     cell_voltage_27:
-      name: "${name} cell voltage 27"
+      name: "cell voltage 27"
     cell_voltage_28:
-      name: "${name} cell voltage 28"
+      name: "cell voltage 28"
     cell_voltage_29:
-      name: "${name} cell voltage 29"
+      name: "cell voltage 29"
     cell_voltage_30:
-      name: "${name} cell voltage 30"
+      name: "cell voltage 30"
     cell_voltage_31:
-      name: "${name} cell voltage 31"
+      name: "cell voltage 31"
     cell_voltage_32:
-      name: "${name} cell voltage 32"
+      name: "cell voltage 32"
     operation_status_bitmask:
-      name: "${name} operation status bitmask"
+      name: "operation status bitmask"
     errors_bitmask:
-      name: "${name} errors bitmask"
+      name: "errors bitmask"
     balancer_status_bitmask:
-      name: "${name} balancer status bitmask"
+      name: "balancer status bitmask"
     software_version:
-      name: "${name} software version"
+      name: "software version"
     short_circuit_error_count:
-      name: "${name} short circuit error count"
+      name: "short circuit error count"
     charge_overcurrent_error_count:
-      name: "${name} charge overcurrent error count"
+      name: "charge overcurrent error count"
     discharge_overcurrent_error_count:
-      name: "${name} discharge overcurrent error count"
+      name: "discharge overcurrent error count"
     cell_overvoltage_error_count:
-      name: "${name} cell overvoltage error count"
+      name: "cell overvoltage error count"
     cell_undervoltage_error_count:
-      name: "${name} cell undervoltage error count"
+      name: "cell undervoltage error count"
     charge_overtemperature_error_count:
-      name: "${name} charge overtemperature error count"
+      name: "charge overtemperature error count"
     charge_undertemperature_error_count:
-      name: "${name} charge undertemperature error count"
+      name: "charge undertemperature error count"
     discharge_overtemperature_error_count:
-      name: "${name} discharge overtemperature error count"
+      name: "discharge overtemperature error count"
     discharge_undertemperature_error_count:
-      name: "${name} discharge undertemperature error count"
+      name: "discharge undertemperature error count"
     battery_overvoltage_error_count:
-      name: "${name} battery overvoltage error count"
+      name: "battery overvoltage error count"
     battery_undervoltage_error_count:
-      name: "${name} battery undervoltage error count"
+      name: "battery undervoltage error count"
 
   # Average current sensor with exponential filtering
   - platform: copy
     source_id: bms0_current
-    name: "${name} average current"
+    name: "average current"
     id: bms0_average_current
     filters:
       - exponential_moving_average:
@@ -265,7 +265,7 @@ select:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     read_eeprom_register:
-      name: "${name} read eeprom register"
+      name: "read eeprom register"
       id: read_eeprom_register0
       optionsmap:
         0xAA: "Error Counts"
@@ -273,25 +273,25 @@ select:
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
 
 text_sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 # Uncomment this section if you want to update the error count sensors periodically
 #

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jbd-bms"

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jbd-bms"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jbd-bms"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -30,7 +30,7 @@ packages:
       - path: packages/remaining_charging_time.yaml
         vars:
           sensor_id: bms0_remaining_charging_time
-          sensor_name: "${name} remaining charging time"
+          sensor_name: "remaining charging time"
           current_sensor_id: bms0_average_current
           capacity_remaining_id: bms0_capacity_remaining
           nominal_capacity_id: bms0_nominal_capacity
@@ -40,7 +40,7 @@ packages:
       - path: packages/remaining_discharging_time.yaml
         vars:
           sensor_id: bms0_remaining_discharging_time
-          sensor_name: "${name} remaining discharging time"
+          sensor_name: "remaining discharging time"
           current_sensor_id: bms0_average_current
           capacity_remaining_id: bms0_capacity_remaining
 
@@ -80,175 +80,175 @@ button:
   - platform: jbd_bms
     jbd_bms_id: bms0
     retrieve_hardware_version:
-      name: "${name} retrieve hardware version"
+      name: "retrieve hardware version"
     retrieve_error_counts:
-      name: "${name} retrieve error counts"
+      name: "retrieve error counts"
     force_soc_reset:
-      name: "${name} force soc reset"
+      name: "force soc reset"
 
 binary_sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
     balancing:
-      name: "${name} balancing"
+      name: "balancing"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
     online_status:
-      name: "${name} online status"
+      name: "online status"
 
 sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
     battery_strings:
-      name: "${name} battery strings"
+      name: "battery strings"
     current:
-      name: "${name} current"
+      name: "current"
       id: bms0_current
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     nominal_capacity:
-      name: "${name} nominal capacity"
+      name: "nominal capacity"
       id: bms0_nominal_capacity
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
       id: bms0_capacity_remaining
     battery_cycle_capacity:
-      name: "${name} battery cycle capacity"
+      name: "battery cycle capacity"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} temperature 5"
+      name: "temperature 5"
     temperature_6:
-      name: "${name} temperature 6"
+      name: "temperature 6"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     cell_voltage_17:
-      name: "${name} cell voltage 17"
+      name: "cell voltage 17"
     cell_voltage_18:
-      name: "${name} cell voltage 18"
+      name: "cell voltage 18"
     cell_voltage_19:
-      name: "${name} cell voltage 19"
+      name: "cell voltage 19"
     cell_voltage_20:
-      name: "${name} cell voltage 20"
+      name: "cell voltage 20"
     cell_voltage_21:
-      name: "${name} cell voltage 21"
+      name: "cell voltage 21"
     cell_voltage_22:
-      name: "${name} cell voltage 22"
+      name: "cell voltage 22"
     cell_voltage_23:
-      name: "${name} cell voltage 23"
+      name: "cell voltage 23"
     cell_voltage_24:
-      name: "${name} cell voltage 24"
+      name: "cell voltage 24"
     cell_voltage_25:
-      name: "${name} cell voltage 25"
+      name: "cell voltage 25"
     cell_voltage_26:
-      name: "${name} cell voltage 26"
+      name: "cell voltage 26"
     cell_voltage_27:
-      name: "${name} cell voltage 27"
+      name: "cell voltage 27"
     cell_voltage_28:
-      name: "${name} cell voltage 28"
+      name: "cell voltage 28"
     cell_voltage_29:
-      name: "${name} cell voltage 29"
+      name: "cell voltage 29"
     cell_voltage_30:
-      name: "${name} cell voltage 30"
+      name: "cell voltage 30"
     cell_voltage_31:
-      name: "${name} cell voltage 31"
+      name: "cell voltage 31"
     cell_voltage_32:
-      name: "${name} cell voltage 32"
+      name: "cell voltage 32"
     operation_status_bitmask:
-      name: "${name} operation status bitmask"
+      name: "operation status bitmask"
     errors_bitmask:
-      name: "${name} errors bitmask"
+      name: "errors bitmask"
     balancer_status_bitmask:
-      name: "${name} balancer status bitmask"
+      name: "balancer status bitmask"
     software_version:
-      name: "${name} software version"
+      name: "software version"
     short_circuit_error_count:
-      name: "${name} short circuit error count"
+      name: "short circuit error count"
     charge_overcurrent_error_count:
-      name: "${name} charge overcurrent error count"
+      name: "charge overcurrent error count"
     discharge_overcurrent_error_count:
-      name: "${name} discharge overcurrent error count"
+      name: "discharge overcurrent error count"
     cell_overvoltage_error_count:
-      name: "${name} cell overvoltage error count"
+      name: "cell overvoltage error count"
     cell_undervoltage_error_count:
-      name: "${name} cell undervoltage error count"
+      name: "cell undervoltage error count"
     charge_overtemperature_error_count:
-      name: "${name} charge overtemperature error count"
+      name: "charge overtemperature error count"
     charge_undertemperature_error_count:
-      name: "${name} charge undertemperature error count"
+      name: "charge undertemperature error count"
     discharge_overtemperature_error_count:
-      name: "${name} discharge overtemperature error count"
+      name: "discharge overtemperature error count"
     discharge_undertemperature_error_count:
-      name: "${name} discharge undertemperature error count"
+      name: "discharge undertemperature error count"
     battery_overvoltage_error_count:
-      name: "${name} battery overvoltage error count"
+      name: "battery overvoltage error count"
     battery_undervoltage_error_count:
-      name: "${name} battery undervoltage error count"
+      name: "battery undervoltage error count"
 
   # Average current sensor with exponential filtering
   - platform: copy
     source_id: bms0_current
-    name: "${name} average current"
+    name: "average current"
     id: bms0_average_current
     filters:
       - exponential_moving_average:
@@ -259,17 +259,17 @@ text_sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 select:
   - platform: jbd_bms
     jbd_bms_id: bms0
     read_eeprom_register:
-      name: "${name} read eeprom register"
+      name: "read eeprom register"
       id: read_eeprom_register0
       optionsmap:
         0xAA: "Error Counts"
@@ -278,9 +278,9 @@ switch:
   - platform: jbd_bms
     jbd_bms_id: bms0
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
 
 # Uncomment this section if you want to update the error count sensors periodically
 #

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -28,7 +28,7 @@ packages:
       - path: packages/remaining_charging_time.yaml
         vars:
           sensor_id: bms0_remaining_charging_time
-          sensor_name: "${name} remaining charging time"
+          sensor_name: "remaining charging time"
           current_sensor_id: bms0_average_current
           capacity_remaining_id: bms0_capacity_remaining
           nominal_capacity_id: bms0_nominal_capacity
@@ -38,7 +38,7 @@ packages:
       - path: packages/remaining_discharging_time.yaml
         vars:
           sensor_id: bms0_remaining_discharging_time
-          sensor_name: "${name} remaining discharging time"
+          sensor_name: "remaining discharging time"
           current_sensor_id: bms0_average_current
           capacity_remaining_id: bms0_capacity_remaining
 
@@ -78,175 +78,175 @@ button:
   - platform: jbd_bms
     jbd_bms_id: bms0
     retrieve_hardware_version:
-      name: "${name} retrieve hardware version"
+      name: "retrieve hardware version"
     retrieve_error_counts:
-      name: "${name} retrieve error counts"
+      name: "retrieve error counts"
     force_soc_reset:
-      name: "${name} force soc reset"
+      name: "force soc reset"
 
 binary_sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
     balancing:
-      name: "${name} balancing"
+      name: "balancing"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
     online_status:
-      name: "${name} online status"
+      name: "online status"
 
 sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
     battery_strings:
-      name: "${name} battery strings"
+      name: "battery strings"
     current:
-      name: "${name} current"
+      name: "current"
       id: bms0_current
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     nominal_capacity:
-      name: "${name} nominal capacity"
+      name: "nominal capacity"
       id: bms0_nominal_capacity
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
       id: bms0_capacity_remaining
     battery_cycle_capacity:
-      name: "${name} battery cycle capacity"
+      name: "battery cycle capacity"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} temperature 5"
+      name: "temperature 5"
     temperature_6:
-      name: "${name} temperature 6"
+      name: "temperature 6"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     cell_voltage_17:
-      name: "${name} cell voltage 17"
+      name: "cell voltage 17"
     cell_voltage_18:
-      name: "${name} cell voltage 18"
+      name: "cell voltage 18"
     cell_voltage_19:
-      name: "${name} cell voltage 19"
+      name: "cell voltage 19"
     cell_voltage_20:
-      name: "${name} cell voltage 20"
+      name: "cell voltage 20"
     cell_voltage_21:
-      name: "${name} cell voltage 21"
+      name: "cell voltage 21"
     cell_voltage_22:
-      name: "${name} cell voltage 22"
+      name: "cell voltage 22"
     cell_voltage_23:
-      name: "${name} cell voltage 23"
+      name: "cell voltage 23"
     cell_voltage_24:
-      name: "${name} cell voltage 24"
+      name: "cell voltage 24"
     cell_voltage_25:
-      name: "${name} cell voltage 25"
+      name: "cell voltage 25"
     cell_voltage_26:
-      name: "${name} cell voltage 26"
+      name: "cell voltage 26"
     cell_voltage_27:
-      name: "${name} cell voltage 27"
+      name: "cell voltage 27"
     cell_voltage_28:
-      name: "${name} cell voltage 28"
+      name: "cell voltage 28"
     cell_voltage_29:
-      name: "${name} cell voltage 29"
+      name: "cell voltage 29"
     cell_voltage_30:
-      name: "${name} cell voltage 30"
+      name: "cell voltage 30"
     cell_voltage_31:
-      name: "${name} cell voltage 31"
+      name: "cell voltage 31"
     cell_voltage_32:
-      name: "${name} cell voltage 32"
+      name: "cell voltage 32"
     operation_status_bitmask:
-      name: "${name} operation status bitmask"
+      name: "operation status bitmask"
     errors_bitmask:
-      name: "${name} errors bitmask"
+      name: "errors bitmask"
     balancer_status_bitmask:
-      name: "${name} balancer status bitmask"
+      name: "balancer status bitmask"
     software_version:
-      name: "${name} software version"
+      name: "software version"
     short_circuit_error_count:
-      name: "${name} short circuit error count"
+      name: "short circuit error count"
     charge_overcurrent_error_count:
-      name: "${name} charge overcurrent error count"
+      name: "charge overcurrent error count"
     discharge_overcurrent_error_count:
-      name: "${name} discharge overcurrent error count"
+      name: "discharge overcurrent error count"
     cell_overvoltage_error_count:
-      name: "${name} cell overvoltage error count"
+      name: "cell overvoltage error count"
     cell_undervoltage_error_count:
-      name: "${name} cell undervoltage error count"
+      name: "cell undervoltage error count"
     charge_overtemperature_error_count:
-      name: "${name} charge overtemperature error count"
+      name: "charge overtemperature error count"
     charge_undertemperature_error_count:
-      name: "${name} charge undertemperature error count"
+      name: "charge undertemperature error count"
     discharge_overtemperature_error_count:
-      name: "${name} discharge overtemperature error count"
+      name: "discharge overtemperature error count"
     discharge_undertemperature_error_count:
-      name: "${name} discharge undertemperature error count"
+      name: "discharge undertemperature error count"
     battery_overvoltage_error_count:
-      name: "${name} battery overvoltage error count"
+      name: "battery overvoltage error count"
     battery_undervoltage_error_count:
-      name: "${name} battery undervoltage error count"
+      name: "battery undervoltage error count"
 
   # Average current sensor with exponential filtering
   - platform: copy
     source_id: bms0_current
-    name: "${name} average current"
+    name: "average current"
     id: bms0_average_current
     filters:
       - exponential_moving_average:
@@ -257,17 +257,17 @@ text_sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 select:
   - platform: jbd_bms
     jbd_bms_id: bms0
     read_eeprom_register:
-      name: "${name} read eeprom register"
+      name: "read eeprom register"
       id: read_eeprom_register0
       optionsmap:
         0xAA: "Error Counts"
@@ -276,9 +276,9 @@ switch:
   - platform: jbd_bms
     jbd_bms_id: bms0
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
 
 # Uncomment this section if you want to update the error count sensors periodically
 #

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jbd-bms"

--- a/packages.local.yaml
+++ b/packages.local.yaml
@@ -4,7 +4,7 @@ remaining_charging_time: !include
   file: packages/remaining_charging_time.yaml
   vars:
     sensor_id: bms0_remaining_charging_time
-    sensor_name: "${name} remaining charging time"
+    sensor_name: "remaining charging time"
     current_sensor_id: bms0_average_current
     capacity_remaining_id: bms0_capacity_remaining
     nominal_capacity_id: bms0_nominal_capacity
@@ -13,6 +13,6 @@ remaining_discharging_time: !include
   file: packages/remaining_discharging_time.yaml
   vars:
     sensor_id: bms0_remaining_discharging_time
-    sensor_name: "${name} remaining discharging time"
+    sensor_name: "remaining discharging time"
     current_sensor_id: bms0_average_current
     capacity_remaining_id: bms0_capacity_remaining

--- a/packages.remote.yaml
+++ b/packages.remote.yaml
@@ -5,7 +5,7 @@ remaining_charging_time:
     - path: packages/remaining_charging_time.yaml
       vars:
         sensor_id: bms0_remaining_charging_time
-        sensor_name: "${name} remaining charging time"
+        sensor_name: "remaining charging time"
         current_sensor_id: bms0_average_current
         capacity_remaining_id: bms0_capacity_remaining
         nominal_capacity_id: bms0_nominal_capacity
@@ -16,6 +16,6 @@ remaining_discharging_time:
     - path: packages/remaining_discharging_time.yaml
       vars:
         sensor_id: bms0_remaining_discharging_time
-        sensor_name: "${name} remaining discharging time"
+        sensor_name: "remaining discharging time"
         current_sensor_id: bms0_average_current
         capacity_remaining_id: bms0_capacity_remaining

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp8266-dummy-receiver.yaml
+++ b/tests/esp8266-dummy-receiver.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-data.yaml
+++ b/tests/esp8266-query-data.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
+++ b/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
@@ -63,12 +63,12 @@ sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     power:
-      name: "${name} power"
+      name: "power"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     state_of_charge:
       id: state_of_charge
-      name: "${name} state of charge"
+      name: "state of charge"
       on_value:
         # Enable charging if the state of charge is below 80%
         - if:
@@ -106,12 +106,12 @@ sensor:
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     charging:
-      name: "${name} charging"
+      name: "charging"
       id: charging
     discharging:
-      name: "${name} discharging"
+      name: "discharging"

--- a/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
+++ b/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-jbd-bms"


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.