### PR TITLE
Remove redundant device name prefix from entity names

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: jbd-bms-ble
-  bms0: "${name} bms0"
-  bms1: "${name} bms1"
+  bms0: "bms0"
+  bms1: "bms1"
   device_description: "Monitor and control a Xiaoxiang Battery Management System (JBD-BMS) via BLE"
   external_components_source: github://syssi/esphome-jbd-bms@main
   bms0_mac_address: 70:3e:97:07:c0:3e
@@ -14,6 +14,11 @@ esphome:
   project:
     name: "syssi.esphome-jbd-bms"
     version: 2.4.0
+  devices:
+    - id: device0
+      name: "${bms0}"
+    - id: device1
+      name: "${bms1}"
 
 esp32:
   board: wemos_d1_mini32
@@ -71,128 +76,166 @@ button:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     retrieve_hardware_version:
-      name: "${bms0} retrieve hardware version"
+      name: "retrieve hardware version"
+      device_id: device0
     retrieve_error_counts:
-      name: "${bms0} retrieve error counts"
+      name: "retrieve error counts"
+      device_id: device0
     force_soc_reset:
-      name: "${bms0} force soc reset"
+      name: "force soc reset"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
     retrieve_hardware_version:
-      name: "${bms1} retrieve hardware version"
+      name: "retrieve hardware version"
+      device_id: device1
     retrieve_error_counts:
-      name: "${bms1} retrieve error counts"
+      name: "retrieve error counts"
+      device_id: device1
     force_soc_reset:
-      name: "${bms1} force soc reset"
+      name: "force soc reset"
+      device_id: device1
 
 binary_sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     balancing:
-      name: "${bms0} balancing"
+      name: "balancing"
+      device_id: device0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
+      device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
+      device_id: device0
     online_status:
-      name: "${bms0} online status"
+      name: "online status"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
     balancing:
-      name: "${bms1} balancing"
+      name: "balancing"
+      device_id: device1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
+      device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
+      device_id: device1
     online_status:
-      name: "${bms1} online status"
+      name: "online status"
+      device_id: device1
 
 sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     power:
-      name: "${bms0} power"
+      name: "power"
+      device_id: device0
     state_of_charge:
-      name: "${bms0} state of charge"
+      name: "state of charge"
+      device_id: device0
     total_voltage:
-      name: "${bms0} total voltage"
+      name: "total voltage"
+      device_id: device0
     average_cell_voltage:
-      name: "${bms0} average cell voltage"
+      name: "average cell voltage"
+      device_id: device0
     delta_cell_voltage:
-      name: "${bms0} delta cell voltage"
+      name: "delta cell voltage"
+      device_id: device0
     # ...
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
     power:
-      name: "${bms1} power"
+      name: "power"
+      device_id: device1
     state_of_charge:
-      name: "${bms1} state of charge"
+      name: "state of charge"
+      device_id: device1
     total_voltage:
-      name: "${bms1} total voltage"
+      name: "total voltage"
+      device_id: device1
     average_cell_voltage:
-      name: "${bms1} average cell voltage"
+      name: "average cell voltage"
+      device_id: device1
     delta_cell_voltage:
-      name: "${bms1} delta cell voltage"
+      name: "delta cell voltage"
+      device_id: device1
     # ...
 
 text_sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     errors:
-      name: "${bms0} errors"
+      name: "errors"
+      device_id: device0
     operation_status:
-      name: "${bms0} operation status"
+      name: "operation status"
+      device_id: device0
     device_model:
-      name: "${bms0} device model"
+      name: "device model"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
     errors:
-      name: "${bms1} errors"
+      name: "errors"
+      device_id: device1
     operation_status:
-      name: "${bms1} operation status"
+      name: "operation status"
+      device_id: device1
     device_model:
-      name: "${bms1} device model"
+      name: "device model"
+      device_id: device1
 
 select:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     read_eeprom_register:
-      name: "${bms0} read eeprom register"
+      name: "read eeprom register"
+      device_id: device0
       optionsmap:
         0xAA: "Error Counts"
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
     read_eeprom_register:
-      name: "${bms1} read eeprom register"
+      name: "read eeprom register"
+      device_id: device1
       optionsmap:
         0xAA: "Error Counts"
 
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${bms0} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
+    device_id: device0
 
   - platform: ble_client
     ble_client_id: client1
-    name: "${bms1} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch1
+    device_id: device1
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
+      device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
+      device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
+      device_id: device1


### PR DESCRIPTION
Use ESPHome sub-devices feature: entity names no longer need the device name prefix since the sub-device name is automatically prepended by Home Assistant via `has_entity_name = True` semantics.

- Remove `${bms0}`/`${bms1}` prefix from all entity `name:` fields in `*multiple-devices*.yaml`
- Add `devices:` block and `device_id:` per entity where missing (jbd-bms, tianpower-bms)
- Add `device_id:` to `ble_client` switches where missing (lolan-bms, jk-bms)