### PR TITLE
Refactor sensor and binary_sensor schema definitions

### DIFF
--- a/components/jbd_bms/binary_sensor.py
+++ b/components/jbd_bms/binary_sensor.py
@@ -17,35 +17,34 @@ ICON_CHARGING = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
 ICON_BALANCING = "mdi:battery-heart-variant"
 
-BINARY_SENSORS = [
-    CONF_CHARGING,
-    CONF_DISCHARGING,
-    CONF_BALANCING,
-    CONF_ONLINE_STATUS,
-]
+# key: binary_sensor_schema kwargs
+BINARY_SENSOR_DEFS = {
+    CONF_CHARGING: {
+        "icon": ICON_CHARGING,
+    },
+    CONF_DISCHARGING: {
+        "icon": ICON_DISCHARGING,
+    },
+    CONF_BALANCING: {
+        "icon": ICON_BALANCING,
+    },
+    CONF_ONLINE_STATUS: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+}
 
 CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            icon=ICON_CHARGING
-        ),
-        cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            icon=ICON_DISCHARGING
-        ),
-        cv.Optional(CONF_BALANCING): binary_sensor.binary_sensor_schema(
-            icon=ICON_BALANCING
-        ),
-        cv.Optional(CONF_ONLINE_STATUS): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_CONNECTIVITY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_JBD_BMS_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -127,6 +127,9 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void set_battery_undervoltage_error_count_sensor(sensor::Sensor *battery_undervoltage_error_count_sensor) {
     battery_undervoltage_error_count_sensor_ = battery_undervoltage_error_count_sensor;
   }
+  void set_battery_cycle_capacity_sensor(sensor::Sensor *battery_cycle_capacity_sensor) {
+    battery_cycle_capacity_sensor_ = battery_cycle_capacity_sensor;
+  }
   void set_cell_voltage_sensor(uint8_t cell, sensor::Sensor *cell_voltage_sensor) {
     this->cells_[cell].cell_voltage_sensor_ = cell_voltage_sensor;
   }
@@ -192,6 +195,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   sensor::Sensor *discharge_undertemperature_error_count_sensor_{nullptr};
   sensor::Sensor *battery_overvoltage_error_count_sensor_{nullptr};
   sensor::Sensor *battery_undervoltage_error_count_sensor_{nullptr};
+  sensor::Sensor *battery_cycle_capacity_sensor_{nullptr};
 
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};

--- a/components/jbd_bms/sensor.py
+++ b/components/jbd_bms/sensor.py
@@ -60,46 +60,6 @@ CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT = "discharge_undertemperature_error_
 CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT = "battery_overvoltage_error_count"
 CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT = "battery_undervoltage_error_count"
 
-CONF_CELL_VOLTAGE_1 = "cell_voltage_1"
-CONF_CELL_VOLTAGE_2 = "cell_voltage_2"
-CONF_CELL_VOLTAGE_3 = "cell_voltage_3"
-CONF_CELL_VOLTAGE_4 = "cell_voltage_4"
-CONF_CELL_VOLTAGE_5 = "cell_voltage_5"
-CONF_CELL_VOLTAGE_6 = "cell_voltage_6"
-CONF_CELL_VOLTAGE_7 = "cell_voltage_7"
-CONF_CELL_VOLTAGE_8 = "cell_voltage_8"
-CONF_CELL_VOLTAGE_9 = "cell_voltage_9"
-CONF_CELL_VOLTAGE_10 = "cell_voltage_10"
-CONF_CELL_VOLTAGE_11 = "cell_voltage_11"
-CONF_CELL_VOLTAGE_12 = "cell_voltage_12"
-CONF_CELL_VOLTAGE_13 = "cell_voltage_13"
-CONF_CELL_VOLTAGE_14 = "cell_voltage_14"
-CONF_CELL_VOLTAGE_15 = "cell_voltage_15"
-CONF_CELL_VOLTAGE_16 = "cell_voltage_16"
-CONF_CELL_VOLTAGE_17 = "cell_voltage_17"
-CONF_CELL_VOLTAGE_18 = "cell_voltage_18"
-CONF_CELL_VOLTAGE_19 = "cell_voltage_19"
-CONF_CELL_VOLTAGE_20 = "cell_voltage_20"
-CONF_CELL_VOLTAGE_21 = "cell_voltage_21"
-CONF_CELL_VOLTAGE_22 = "cell_voltage_22"
-CONF_CELL_VOLTAGE_23 = "cell_voltage_23"
-CONF_CELL_VOLTAGE_24 = "cell_voltage_24"
-CONF_CELL_VOLTAGE_25 = "cell_voltage_25"
-CONF_CELL_VOLTAGE_26 = "cell_voltage_26"
-CONF_CELL_VOLTAGE_27 = "cell_voltage_27"
-CONF_CELL_VOLTAGE_28 = "cell_voltage_28"
-CONF_CELL_VOLTAGE_29 = "cell_voltage_29"
-CONF_CELL_VOLTAGE_30 = "cell_voltage_30"
-CONF_CELL_VOLTAGE_31 = "cell_voltage_31"
-CONF_CELL_VOLTAGE_32 = "cell_voltage_32"
-
-CONF_TEMPERATURE_1 = "temperature_1"
-CONF_TEMPERATURE_2 = "temperature_2"
-CONF_TEMPERATURE_3 = "temperature_3"
-CONF_TEMPERATURE_4 = "temperature_4"
-CONF_TEMPERATURE_5 = "temperature_5"
-CONF_TEMPERATURE_6 = "temperature_6"
-
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_BATTERY_STRINGS = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
@@ -119,577 +79,262 @@ UNIT_SECONDS = "s"
 UNIT_HOURS = "h"
 UNIT_AMPERE_HOURS = "Ah"
 
-CELLS = [
-    CONF_CELL_VOLTAGE_1,
-    CONF_CELL_VOLTAGE_2,
-    CONF_CELL_VOLTAGE_3,
-    CONF_CELL_VOLTAGE_4,
-    CONF_CELL_VOLTAGE_5,
-    CONF_CELL_VOLTAGE_6,
-    CONF_CELL_VOLTAGE_7,
-    CONF_CELL_VOLTAGE_8,
-    CONF_CELL_VOLTAGE_9,
-    CONF_CELL_VOLTAGE_10,
-    CONF_CELL_VOLTAGE_11,
-    CONF_CELL_VOLTAGE_12,
-    CONF_CELL_VOLTAGE_13,
-    CONF_CELL_VOLTAGE_14,
-    CONF_CELL_VOLTAGE_15,
-    CONF_CELL_VOLTAGE_16,
-    CONF_CELL_VOLTAGE_17,
-    CONF_CELL_VOLTAGE_18,
-    CONF_CELL_VOLTAGE_19,
-    CONF_CELL_VOLTAGE_20,
-    CONF_CELL_VOLTAGE_21,
-    CONF_CELL_VOLTAGE_22,
-    CONF_CELL_VOLTAGE_23,
-    CONF_CELL_VOLTAGE_24,
-    CONF_CELL_VOLTAGE_25,
-    CONF_CELL_VOLTAGE_26,
-    CONF_CELL_VOLTAGE_27,
-    CONF_CELL_VOLTAGE_28,
-    CONF_CELL_VOLTAGE_29,
-    CONF_CELL_VOLTAGE_30,
-    CONF_CELL_VOLTAGE_31,
-    CONF_CELL_VOLTAGE_32,
-]
+CELLS = [f"cell_voltage_{i}" for i in range(1, 33)]
 
-TEMPERATURES = [
-    CONF_TEMPERATURE_1,
-    CONF_TEMPERATURE_2,
-    CONF_TEMPERATURE_3,
-    CONF_TEMPERATURE_4,
-    CONF_TEMPERATURE_5,
-    CONF_TEMPERATURE_6,
-]
+TEMPERATURES = [f"temperature_{i}" for i in range(1, 7)]
 
-SENSORS = [
-    CONF_STATE_OF_CHARGE,
-    CONF_TOTAL_VOLTAGE,
-    CONF_CURRENT,
-    CONF_POWER,
-    CONF_CHARGING_POWER,
-    CONF_DISCHARGING_POWER,
-    CONF_NOMINAL_CAPACITY,
-    CONF_CHARGING_CYCLES,
-    CONF_CAPACITY_REMAINING,
-    CONF_MIN_CELL_VOLTAGE,
-    CONF_MAX_CELL_VOLTAGE,
-    CONF_MIN_VOLTAGE_CELL,
-    CONF_MAX_VOLTAGE_CELL,
-    CONF_DELTA_CELL_VOLTAGE,
-    CONF_AVERAGE_CELL_VOLTAGE,
-    CONF_OPERATION_STATUS_BITMASK,
-    CONF_ERRORS_BITMASK,
-    CONF_BALANCER_STATUS_BITMASK,
-    CONF_BATTERY_STRINGS,
-    CONF_SOFTWARE_VERSION,
-    CONF_SHORT_CIRCUIT_ERROR_COUNT,
-    CONF_CHARGE_OVERCURRENT_ERROR_COUNT,
-    CONF_DISCHARGE_OVERCURRENT_ERROR_COUNT,
-    CONF_CELL_OVERVOLTAGE_ERROR_COUNT,
-    CONF_CELL_UNDERVOLTAGE_ERROR_COUNT,
-    CONF_CHARGE_OVERTEMPERATURE_ERROR_COUNT,
-    CONF_CHARGE_UNDERTEMPERATURE_ERROR_COUNT,
-    CONF_DISCHARGE_OVERTEMPERATURE_ERROR_COUNT,
-    CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT,
-    CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT,
-    CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT,
-]
+# key: sensor_schema kwargs
+SENSOR_DEFS = {
+    CONF_STATE_OF_CHARGE: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_BATTERY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_TOTAL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_CURRENT_DC,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_NOMINAL_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_NOMINAL_CAPACITY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_CYCLES: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_CHARGING_CYCLES,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_CAPACITY_REMAINING: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_CAPACITY_REMAINING,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MIN_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MAX_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MIN_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MAX_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DELTA_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 4,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AVERAGE_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 4,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_OPERATION_STATUS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_OPERATION_STATUS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_ERRORS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_ERRORS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BALANCER_STATUS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BALANCER_STATUS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BATTERY_STRINGS: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BATTERY_STRINGS,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_SOFTWARE_VERSION: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_SOFTWARE_VERSION,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_SHORT_CIRCUIT_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_OVERCURRENT_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_OVERCURRENT_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_OVERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_UNDERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_OVERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_UNDERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_OVERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_CYCLE_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_BATTERY_CYCLE_CAPACITY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+}
 
-# pylint: disable=too-many-function-args
-CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_PERCENT,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_BATTERY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_STRINGS): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_BATTERY_STRINGS,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon=ICON_CURRENT_DC,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_NOMINAL_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_NOMINAL_CAPACITY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_CYCLES): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_CHARGING_CYCLES,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_CAPACITY_REMAINING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_CAPACITY_REMAINING,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_CYCLE_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_BATTERY_CYCLE_CAPACITY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_TOTAL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_AVERAGE_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=4,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_ERRORS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_ERRORS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_OPERATION_STATUS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_OPERATION_STATUS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_BALANCER_STATUS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_BALANCER_STATUS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MIN_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MAX_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MIN_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MAX_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DELTA_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=4,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_6): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_6): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_7): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_8): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_9): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_10): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_11): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_12): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_13): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_14): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_15): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_16): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_17): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_18): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_19): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_20): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_21): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_22): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_23): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_24): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_25): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_26): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_27): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_28): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_29): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_30): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_31): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_32): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_SOFTWARE_VERSION): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_SOFTWARE_VERSION,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_SHORT_CIRCUIT_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGE_OVERCURRENT_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGE_OVERCURRENT_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_OVERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_UNDERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGE_OVERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGE_UNDERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGE_OVERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
+_CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_VOLT,
+    icon=ICON_EMPTY,
+    accuracy_decimals=3,
+    device_class=DEVICE_CLASS_VOLTAGE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+_TEMPERATURE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    icon=ICON_EMPTY,
+    accuracy_decimals=1,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+CONFIG_SCHEMA = (
+    JBD_BMS_COMPONENT_SCHEMA.extend(
+        {
+            cv.Optional(key): sensor.sensor_schema(**kwargs)
+            for key, kwargs in SENSOR_DEFS.items()
+        }
+    )
+    .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
+    .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES})
 )
 
 
@@ -705,7 +350,7 @@ async def to_code(config):
             conf = config[key]
             sens = await sensor.new_sensor(conf)
             cg.add(hub.set_cell_voltage_sensor(i, sens))
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -134,6 +134,9 @@ class JbdBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   void set_battery_undervoltage_error_count_sensor(sensor::Sensor *battery_undervoltage_error_count_sensor) {
     battery_undervoltage_error_count_sensor_ = battery_undervoltage_error_count_sensor;
   }
+  void set_battery_cycle_capacity_sensor(sensor::Sensor *battery_cycle_capacity_sensor) {
+    battery_cycle_capacity_sensor_ = battery_cycle_capacity_sensor;
+  }
   void set_cell_voltage_sensor(uint8_t cell, sensor::Sensor *cell_voltage_sensor) {
     this->cells_[cell].cell_voltage_sensor_ = cell_voltage_sensor;
   }
@@ -204,6 +207,7 @@ class JbdBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   sensor::Sensor *discharge_undertemperature_error_count_sensor_{nullptr};
   sensor::Sensor *battery_overvoltage_error_count_sensor_{nullptr};
   sensor::Sensor *battery_undervoltage_error_count_sensor_{nullptr};
+  sensor::Sensor *battery_cycle_capacity_sensor_{nullptr};
 
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};

--- a/components/jbd_bms_ble/sensor.py
+++ b/components/jbd_bms_ble/sensor.py
@@ -60,46 +60,6 @@ CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT = "discharge_undertemperature_error_
 CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT = "battery_overvoltage_error_count"
 CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT = "battery_undervoltage_error_count"
 
-CONF_CELL_VOLTAGE_1 = "cell_voltage_1"
-CONF_CELL_VOLTAGE_2 = "cell_voltage_2"
-CONF_CELL_VOLTAGE_3 = "cell_voltage_3"
-CONF_CELL_VOLTAGE_4 = "cell_voltage_4"
-CONF_CELL_VOLTAGE_5 = "cell_voltage_5"
-CONF_CELL_VOLTAGE_6 = "cell_voltage_6"
-CONF_CELL_VOLTAGE_7 = "cell_voltage_7"
-CONF_CELL_VOLTAGE_8 = "cell_voltage_8"
-CONF_CELL_VOLTAGE_9 = "cell_voltage_9"
-CONF_CELL_VOLTAGE_10 = "cell_voltage_10"
-CONF_CELL_VOLTAGE_11 = "cell_voltage_11"
-CONF_CELL_VOLTAGE_12 = "cell_voltage_12"
-CONF_CELL_VOLTAGE_13 = "cell_voltage_13"
-CONF_CELL_VOLTAGE_14 = "cell_voltage_14"
-CONF_CELL_VOLTAGE_15 = "cell_voltage_15"
-CONF_CELL_VOLTAGE_16 = "cell_voltage_16"
-CONF_CELL_VOLTAGE_17 = "cell_voltage_17"
-CONF_CELL_VOLTAGE_18 = "cell_voltage_18"
-CONF_CELL_VOLTAGE_19 = "cell_voltage_19"
-CONF_CELL_VOLTAGE_20 = "cell_voltage_20"
-CONF_CELL_VOLTAGE_21 = "cell_voltage_21"
-CONF_CELL_VOLTAGE_22 = "cell_voltage_22"
-CONF_CELL_VOLTAGE_23 = "cell_voltage_23"
-CONF_CELL_VOLTAGE_24 = "cell_voltage_24"
-CONF_CELL_VOLTAGE_25 = "cell_voltage_25"
-CONF_CELL_VOLTAGE_26 = "cell_voltage_26"
-CONF_CELL_VOLTAGE_27 = "cell_voltage_27"
-CONF_CELL_VOLTAGE_28 = "cell_voltage_28"
-CONF_CELL_VOLTAGE_29 = "cell_voltage_29"
-CONF_CELL_VOLTAGE_30 = "cell_voltage_30"
-CONF_CELL_VOLTAGE_31 = "cell_voltage_31"
-CONF_CELL_VOLTAGE_32 = "cell_voltage_32"
-
-CONF_TEMPERATURE_1 = "temperature_1"
-CONF_TEMPERATURE_2 = "temperature_2"
-CONF_TEMPERATURE_3 = "temperature_3"
-CONF_TEMPERATURE_4 = "temperature_4"
-CONF_TEMPERATURE_5 = "temperature_5"
-CONF_TEMPERATURE_6 = "temperature_6"
-
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_BATTERY_STRINGS = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
@@ -119,578 +79,264 @@ UNIT_SECONDS = "s"
 UNIT_HOURS = "h"
 UNIT_AMPERE_HOURS = "Ah"
 
-CELLS = [
-    CONF_CELL_VOLTAGE_1,
-    CONF_CELL_VOLTAGE_2,
-    CONF_CELL_VOLTAGE_3,
-    CONF_CELL_VOLTAGE_4,
-    CONF_CELL_VOLTAGE_5,
-    CONF_CELL_VOLTAGE_6,
-    CONF_CELL_VOLTAGE_7,
-    CONF_CELL_VOLTAGE_8,
-    CONF_CELL_VOLTAGE_9,
-    CONF_CELL_VOLTAGE_10,
-    CONF_CELL_VOLTAGE_11,
-    CONF_CELL_VOLTAGE_12,
-    CONF_CELL_VOLTAGE_13,
-    CONF_CELL_VOLTAGE_14,
-    CONF_CELL_VOLTAGE_15,
-    CONF_CELL_VOLTAGE_16,
-    CONF_CELL_VOLTAGE_17,
-    CONF_CELL_VOLTAGE_18,
-    CONF_CELL_VOLTAGE_19,
-    CONF_CELL_VOLTAGE_20,
-    CONF_CELL_VOLTAGE_21,
-    CONF_CELL_VOLTAGE_22,
-    CONF_CELL_VOLTAGE_23,
-    CONF_CELL_VOLTAGE_24,
-    CONF_CELL_VOLTAGE_25,
-    CONF_CELL_VOLTAGE_26,
-    CONF_CELL_VOLTAGE_27,
-    CONF_CELL_VOLTAGE_28,
-    CONF_CELL_VOLTAGE_29,
-    CONF_CELL_VOLTAGE_30,
-    CONF_CELL_VOLTAGE_31,
-    CONF_CELL_VOLTAGE_32,
-]
+CELLS = [f"cell_voltage_{i}" for i in range(1, 33)]
 
-TEMPERATURES = [
-    CONF_TEMPERATURE_1,
-    CONF_TEMPERATURE_2,
-    CONF_TEMPERATURE_3,
-    CONF_TEMPERATURE_4,
-    CONF_TEMPERATURE_5,
-    CONF_TEMPERATURE_6,
-]
+TEMPERATURES = [f"temperature_{i}" for i in range(1, 7)]
 
-SENSORS = [
-    CONF_STATE_OF_CHARGE,
-    CONF_TOTAL_VOLTAGE,
-    CONF_CURRENT,
-    CONF_POWER,
-    CONF_CHARGING_POWER,
-    CONF_DISCHARGING_POWER,
-    CONF_NOMINAL_CAPACITY,
-    CONF_CHARGING_CYCLES,
-    CONF_CAPACITY_REMAINING,
-    CONF_MIN_CELL_VOLTAGE,
-    CONF_MAX_CELL_VOLTAGE,
-    CONF_MIN_VOLTAGE_CELL,
-    CONF_MAX_VOLTAGE_CELL,
-    CONF_DELTA_CELL_VOLTAGE,
-    CONF_AVERAGE_CELL_VOLTAGE,
-    CONF_OPERATION_STATUS_BITMASK,
-    CONF_ERRORS_BITMASK,
-    CONF_BALANCER_STATUS_BITMASK,
-    CONF_BATTERY_STRINGS,
-    CONF_SOFTWARE_VERSION,
-    CONF_SHORT_CIRCUIT_ERROR_COUNT,
-    CONF_CHARGE_OVERCURRENT_ERROR_COUNT,
-    CONF_DISCHARGE_OVERCURRENT_ERROR_COUNT,
-    CONF_CELL_OVERVOLTAGE_ERROR_COUNT,
-    CONF_CELL_UNDERVOLTAGE_ERROR_COUNT,
-    CONF_CHARGE_OVERTEMPERATURE_ERROR_COUNT,
-    CONF_CHARGE_UNDERTEMPERATURE_ERROR_COUNT,
-    CONF_DISCHARGE_OVERTEMPERATURE_ERROR_COUNT,
-    CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT,
-    CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT,
-    CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT,
-]
+# key: sensor_schema kwargs
+SENSOR_DEFS = {
+    CONF_STATE_OF_CHARGE: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_BATTERY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_TOTAL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_CURRENT_DC,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_NOMINAL_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_NOMINAL_CAPACITY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_CYCLES: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_CHARGING_CYCLES,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_CAPACITY_REMAINING: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_CAPACITY_REMAINING,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MIN_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MAX_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MIN_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MAX_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DELTA_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 4,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AVERAGE_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 4,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_OPERATION_STATUS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_OPERATION_STATUS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_ERRORS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_ERRORS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BALANCER_STATUS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BALANCER_STATUS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BATTERY_STRINGS: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BATTERY_STRINGS,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_SOFTWARE_VERSION: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_SOFTWARE_VERSION,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_SHORT_CIRCUIT_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_OVERCURRENT_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_OVERCURRENT_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_OVERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_UNDERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_OVERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_UNDERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_OVERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_CYCLE_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_BATTERY_CYCLE_CAPACITY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+}
 
-# pylint: disable=too-many-function-args
-CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_PERCENT,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_BATTERY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_STRINGS): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_BATTERY_STRINGS,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon=ICON_CURRENT_DC,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_NOMINAL_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_NOMINAL_CAPACITY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_CYCLES): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_CHARGING_CYCLES,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_CAPACITY_REMAINING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_CAPACITY_REMAINING,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_CYCLE_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_BATTERY_CYCLE_CAPACITY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_TOTAL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_AVERAGE_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=4,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_ERRORS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_ERRORS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_OPERATION_STATUS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_OPERATION_STATUS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_BALANCER_STATUS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_BALANCER_STATUS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MIN_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MAX_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MIN_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MAX_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DELTA_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=4,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_6): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_6): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_7): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_8): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_9): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_10): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_11): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_12): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_13): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_14): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_15): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_16): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_17): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_18): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_19): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_20): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_21): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_22): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_23): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_24): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_25): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_26): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_27): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_28): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_29): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_30): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_31): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_32): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_SOFTWARE_VERSION): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_SOFTWARE_VERSION,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_SHORT_CIRCUIT_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGE_OVERCURRENT_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGE_OVERCURRENT_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_OVERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_UNDERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGE_OVERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGE_UNDERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGE_OVERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGE_UNDERTEMPERATURE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
-).extend(JBD_BMS_BLE_COMPONENT_SCHEMA)
+_CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_VOLT,
+    icon=ICON_EMPTY,
+    accuracy_decimals=3,
+    device_class=DEVICE_CLASS_VOLTAGE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+_TEMPERATURE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    icon=ICON_EMPTY,
+    accuracy_decimals=1,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+CONFIG_SCHEMA = (
+    JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
+        {
+            cv.Optional(key): sensor.sensor_schema(**kwargs)
+            for key, kwargs in SENSOR_DEFS.items()
+        }
+    )
+    .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
+    .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES})
+    .extend(JBD_BMS_BLE_COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):
@@ -705,7 +351,7 @@ async def to_code(config):
             conf = config[key]
             sens = await sensor.new_sensor(conf)
             cg.add(hub.set_cell_voltage_sensor(i, sens))
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)


### PR DESCRIPTION
Replace flat SENSORS/BINARY_SENSORS lists and manual CONFIG_SCHEMA entries with SENSOR_DEFS/BINARY_SENSOR_DEFS dicts. Reduces repetition and makes adding new entities easier.

Reference: syssi/esphome-daly-bms#85