### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -30,7 +30,7 @@ static const uint8_t JBD_MOS_CHARGE = 0x01;
 static const uint8_t JBD_MOS_DISCHARGE = 0x02;
 
 static const uint8_t ERRORS_SIZE = 16;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Cell overvoltage",               // 0x00
     "Cell undervoltage",              // 0x01
     "Pack overvoltage",               // 0x02
@@ -50,7 +50,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
 };
 
 static const uint8_t OPERATION_STATUS_SIZE = 8;
-static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
+static constexpr const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
     "Charging",        // 0x01
     "Discharging",     // 0x02
     "Unknown (0x04)",  // 0x04

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -53,7 +53,7 @@ static const uint8_t JBD_MOS_CHARGE = 0x01;
 static const uint8_t JBD_MOS_DISCHARGE = 0x02;
 
 static const uint8_t ERRORS_SIZE = 16;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Cell overvoltage",               // 0x00
     "Cell undervoltage",              // 0x01
     "Pack overvoltage",               // 0x02
@@ -73,7 +73,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
 };
 
 static const uint8_t OPERATION_STATUS_SIZE = 8;
-static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
+static constexpr const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
     "Charging",        // 0x01
     "Discharging",     // 0x02
     "Unknown (0x04)",  // 0x04


### PR DESCRIPTION
## Summary

- Replace `static const char *const` with `static constexpr const char *const` for string arrays in `components/jbd_bms_ble/jbd_bms_ble.cpp` and `components/jbd_bms/jbd_bms.cpp`.

## Details

Using `static constexpr const char *const` for string arrays ensures that they are evaluated and placed into the read-only segment (Flash) at compile time rather than occupying RAM at runtime. This aligns with the style used in the ESPHome core (e.g. `bme68x_bsec2.cpp`) and is a meaningful optimization on embedded targets where RAM is scarce.

The change affects the `ERRORS` and `OPERATION_STATUS` arrays in both components. Single-string constants such as `TAG` are intentionally left unchanged.