### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/jbd_bms/button/jbd_button.cpp
+++ b/components/jbd_bms/button/jbd_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 static const char *const TAG = "jbd_bms.button";
 
@@ -20,5 +19,4 @@ void JbdButton::press_action() {
   this->parent_->send_command(JBD_CMD_READ, this->holding_register_);
 }
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/button/jbd_button.h
+++ b/components/jbd_bms/button/jbd_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 class JbdBms;
 class JbdButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class JbdButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 static const char *const TAG = "jbd_bms";
 
@@ -623,5 +622,4 @@ std::string JbdBms::bitmask_to_string_(const char *const messages[], const uint8
   return values;
 }
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -8,8 +8,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 class JbdBms : public uart::UARTDevice, public PollingComponent {
  public:
@@ -252,5 +251,4 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   }
 };
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/select/jbd_select.cpp
+++ b/components/jbd_bms/select/jbd_select.cpp
@@ -1,8 +1,7 @@
 #include "jbd_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 static const char *const TAG = "jbd_bms.select";
 
@@ -29,5 +28,4 @@ void JbdSelect::control(const std::string &value) {
   ESP_LOGW(TAG, "Invalid value %s", value.c_str());
 }
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/select/jbd_select.h
+++ b/components/jbd_bms/select/jbd_select.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 class JbdBms;
 class JbdSelect : public select::Select, public Component {
@@ -25,5 +24,4 @@ class JbdSelect : public select::Select, public Component {
   JbdBms *parent_;
 };
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/switch/jbd_switch.cpp
+++ b/components/jbd_bms/switch/jbd_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 static const char *const TAG = "jbd_bms.switch";
 
@@ -17,5 +16,4 @@ void JbdSwitch::write_state(bool state) {
   // this->parent_->write_register(0x01, 0x0000);
 }
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms/switch/jbd_switch.h
+++ b/components/jbd_bms/switch/jbd_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jbd_bms {
+namespace esphome::jbd_bms {
 
 class JbdBms;
 class JbdSwitch : public switch_::Switch, public Component {
@@ -24,5 +23,4 @@ class JbdSwitch : public switch_::Switch, public Component {
   uint8_t bitmask_;
 };
 
-}  // namespace jbd_bms
-}  // namespace esphome
+}  // namespace esphome::jbd_bms

--- a/components/jbd_bms_ble/button/jbd_button.cpp
+++ b/components/jbd_bms_ble/button/jbd_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 static const char *const TAG = "jbd_bms_ble.button";
 
@@ -20,5 +19,4 @@ void JbdButton::press_action() {
   this->parent_->send_command(JBD_CMD_READ, this->holding_register_);
 }
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/button/jbd_button.h
+++ b/components/jbd_bms_ble/button/jbd_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 class JbdBmsBle;
 class JbdButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class JbdButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 static const char *const TAG = "jbd_bms_ble";
 
@@ -877,5 +876,4 @@ std::string JbdBmsBle::bitmask_to_string_(const char *const messages[], const ui
   return values;
 }
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -13,8 +13,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -296,7 +295,6 @@ class JbdBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   void check_auth_timeout_();
 };
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble
 
 #endif

--- a/components/jbd_bms_ble/select/jbd_select.cpp
+++ b/components/jbd_bms_ble/select/jbd_select.cpp
@@ -1,8 +1,7 @@
 #include "jbd_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 static const char *const TAG = "jbd_bms_ble.select";
 
@@ -29,5 +28,4 @@ void JbdSelect::control(const std::string &value) {
   ESP_LOGW(TAG, "Invalid value %s", value.c_str());
 }
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/select/jbd_select.h
+++ b/components/jbd_bms_ble/select/jbd_select.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 class JbdBmsBle;
 class JbdSelect : public select::Select, public Component {
@@ -25,5 +24,4 @@ class JbdSelect : public select::Select, public Component {
   JbdBmsBle *parent_;
 };
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/switch/jbd_switch.cpp
+++ b/components/jbd_bms_ble/switch/jbd_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 static const char *const TAG = "jbd_bms_ble.switch";
 
@@ -17,5 +16,4 @@ void JbdSwitch::write_state(bool state) {
   // this->parent_->write_register(0x01, 0x0000);
 }
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/switch/jbd_switch.h
+++ b/components/jbd_bms_ble/switch/jbd_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace jbd_bms_ble {
+namespace esphome::jbd_bms_ble {
 
 class JbdBmsBle;
 class JbdSwitch : public switch_::Switch, public Component {
@@ -24,5 +23,4 @@ class JbdSwitch : public switch_::Switch, public Component {
   uint8_t bitmask_;
 };
 
-}  // namespace jbd_bms_ble
-}  // namespace esphome
+}  // namespace esphome::jbd_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.