### PR TITLE
Fix format specifiers for data.size() in ESP_LOG calls

### DIFF
--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -201,7 +201,7 @@ void JbdBms::on_cell_info_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGI(TAG, "Cell info frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Cell info frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   uint8_t data_len = data.size();
@@ -249,7 +249,7 @@ void JbdBms::on_error_counts_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGI(TAG, "Error counts frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Error counts frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   uint8_t data_len = data.size();
@@ -279,7 +279,7 @@ void JbdBms::on_hardware_info_data_(const std::vector<uint8_t> &data) {
     return (uint32_t(jbd_get_16bit(i + 0)) << 16) | (uint32_t(jbd_get_16bit(i + 2)) << 0);
   };
 
-  ESP_LOGI(TAG, "Hardware info frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Hardware info frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   ESP_LOGD(TAG, "  Device model: %s", this->device_model_.c_str());
@@ -354,7 +354,7 @@ void JbdBms::on_hardware_info_data_(const std::vector<uint8_t> &data) {
 }
 
 void JbdBms::on_hardware_version_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGI(TAG, "Hardware version frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Hardware version frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   // Byte Len  Payload                                              Content

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -322,7 +322,7 @@ void JbdBmsBle::assemble(const uint8_t *data, uint16_t length) {
         ESP_LOGW(TAG, "CRC check failed! 0x%04X != 0x%04X", computed_crc, remote_crc);
       }
     } else {
-      ESP_LOGW(TAG, "Invalid frame length: expected %d, got %d", frame_len, this->frame_buffer_.size());
+      ESP_LOGW(TAG, "Invalid frame length: expected %d, got %zu", frame_len, this->frame_buffer_.size());
     }
     this->frame_buffer_.clear();
   }
@@ -468,7 +468,7 @@ void JbdBmsBle::on_cell_info_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGI(TAG, "Cell info frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Cell info frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   uint8_t data_len = data.size();
@@ -519,7 +519,7 @@ void JbdBmsBle::on_hardware_info_data_(const std::vector<uint8_t> &data) {
     return (uint32_t(jbd_get_16bit(i + 0)) << 16) | (uint32_t(jbd_get_16bit(i + 2)) << 0);
   };
 
-  ESP_LOGI(TAG, "Hardware info frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Hardware info frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   ESP_LOGD(TAG, "  Device model: %s", this->device_model_.c_str());
@@ -598,7 +598,7 @@ void JbdBmsBle::on_error_counts_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGI(TAG, "Error counts frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Error counts frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   uint8_t data_len = data.size();
@@ -621,7 +621,7 @@ void JbdBmsBle::on_error_counts_data_(const std::vector<uint8_t> &data) {
 }
 
 void JbdBmsBle::on_hardware_version_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGI(TAG, "Hardware version frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Hardware version frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   // Byte Len  Payload                                              Content


### PR DESCRIPTION
Replace `%d` with `%zu` where `data.size()` or `frame_buffer_.size()` is passed, since `size_t` is unsigned long and `%d` expects int.