### PR TITLE
Add protection status binary sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ __pycache__/
 *$py.class
 
 local/
-docs/missing-features-plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 *$py.class
 
 local/
+docs/missing-features-plan.md

--- a/components/jbd_bms/binary_sensor.py
+++ b/components/jbd_bms/binary_sensor.py
@@ -1,7 +1,11 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import (
+    DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_PROBLEM,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
 
 from . import CONF_JBD_BMS_ID, JBD_BMS_COMPONENT_SCHEMA
 from .const import CONF_CHARGING, CONF_DISCHARGING
@@ -12,6 +16,19 @@ CODEOWNERS = ["@syssi"]
 
 CONF_BALANCING = "balancing"
 CONF_ONLINE_STATUS = "online_status"
+CONF_CELL_OVERVOLTAGE_PROTECTION = "cell_overvoltage_protection"
+CONF_CELL_UNDERVOLTAGE_PROTECTION = "cell_undervoltage_protection"
+CONF_PACK_OVERVOLTAGE_PROTECTION = "pack_overvoltage_protection"
+CONF_PACK_UNDERVOLTAGE_PROTECTION = "pack_undervoltage_protection"
+CONF_CHARGE_OVERTEMPERATURE_PROTECTION = "charge_overtemperature_protection"
+CONF_CHARGE_UNDERTEMPERATURE_PROTECTION = "charge_undertemperature_protection"
+CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION = "discharge_overtemperature_protection"
+CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION = "discharge_undertemperature_protection"
+CONF_CHARGE_OVERCURRENT_PROTECTION = "charge_overcurrent_protection"
+CONF_DISCHARGE_OVERCURRENT_PROTECTION = "discharge_overcurrent_protection"
+CONF_SHORT_CIRCUIT_PROTECTION = "short_circuit_protection"
+CONF_IC_FRONTEND_ERROR = "ic_frontend_error"
+CONF_MOSFET_SOFTWARE_LOCK = "mosfet_software_lock"
 
 ICON_CHARGING = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
@@ -30,6 +47,58 @@ BINARY_SENSOR_DEFS = {
     },
     CONF_ONLINE_STATUS: {
         "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CELL_OVERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CELL_UNDERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_PACK_OVERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_PACK_UNDERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGE_OVERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGE_UNDERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGE_OVERCURRENT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGE_OVERCURRENT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_SHORT_CIRCUIT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_IC_FRONTEND_ERROR: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_MOSFET_SOFTWARE_LOCK: {
+        "device_class": DEVICE_CLASS_PROBLEM,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
 }

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -320,6 +320,19 @@ void JbdBms::on_hardware_info_data_(const std::vector<uint8_t> &data) {
   uint16_t errors_bitmask = jbd_get_16bit(16);
   this->publish_state_(this->errors_bitmask_sensor_, (float) errors_bitmask);
   this->publish_state_(this->errors_text_sensor_, this->bitmask_to_string_(ERRORS, ERRORS_SIZE, errors_bitmask));
+  this->publish_state_(this->cell_overvoltage_protection_binary_sensor_, errors_bitmask & (1 << 0));
+  this->publish_state_(this->cell_undervoltage_protection_binary_sensor_, errors_bitmask & (1 << 1));
+  this->publish_state_(this->pack_overvoltage_protection_binary_sensor_, errors_bitmask & (1 << 2));
+  this->publish_state_(this->pack_undervoltage_protection_binary_sensor_, errors_bitmask & (1 << 3));
+  this->publish_state_(this->charge_overtemperature_protection_binary_sensor_, errors_bitmask & (1 << 4));
+  this->publish_state_(this->charge_undertemperature_protection_binary_sensor_, errors_bitmask & (1 << 5));
+  this->publish_state_(this->discharge_overtemperature_protection_binary_sensor_, errors_bitmask & (1 << 6));
+  this->publish_state_(this->discharge_undertemperature_protection_binary_sensor_, errors_bitmask & (1 << 7));
+  this->publish_state_(this->charge_overcurrent_protection_binary_sensor_, errors_bitmask & (1 << 8));
+  this->publish_state_(this->discharge_overcurrent_protection_binary_sensor_, errors_bitmask & (1 << 9));
+  this->publish_state_(this->short_circuit_protection_binary_sensor_, errors_bitmask & (1 << 10));
+  this->publish_state_(this->ic_frontend_error_binary_sensor_, errors_bitmask & (1 << 11));
+  this->publish_state_(this->mosfet_software_lock_binary_sensor_, errors_bitmask & (1 << 12));
 
   // 18    1   0x80                   Version                                      0x10 = 1.0, 0x80 = 8.0
   this->publish_state_(this->software_version_sensor_, (data[18] >> 4) + ((data[18] & 0x0f) * 0.1f));
@@ -426,6 +439,21 @@ void JbdBms::dump_config() {  // NOLINT(google-readability-function-size,readabi
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Online status", this->online_status_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Cell overvoltage protection", this->cell_overvoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Cell undervoltage protection", this->cell_undervoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Pack overvoltage protection", this->pack_overvoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Pack undervoltage protection", this->pack_undervoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charge overtemperature protection", this->charge_overtemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charge undertemperature protection", this->charge_undertemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharge overtemperature protection",
+                    this->discharge_overtemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharge undertemperature protection",
+                    this->discharge_undertemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charge overcurrent protection", this->charge_overcurrent_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharge overcurrent protection", this->discharge_overcurrent_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Short circuit protection", this->short_circuit_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "IC front-end error", this->ic_frontend_error_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Mosfet Software Lock", this->mosfet_software_lock_binary_sensor_);
 
   LOG_SENSOR("", "Total voltage", this->total_voltage_sensor_);
   LOG_SENSOR("", "Battery strings", this->battery_strings_sensor_);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -30,6 +30,55 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void set_online_status_binary_sensor(binary_sensor::BinarySensor *online_status_binary_sensor) {
     online_status_binary_sensor_ = online_status_binary_sensor;
   }
+  void set_cell_overvoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *cell_overvoltage_protection_binary_sensor) {
+    cell_overvoltage_protection_binary_sensor_ = cell_overvoltage_protection_binary_sensor;
+  }
+  void set_cell_undervoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *cell_undervoltage_protection_binary_sensor) {
+    cell_undervoltage_protection_binary_sensor_ = cell_undervoltage_protection_binary_sensor;
+  }
+  void set_pack_overvoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *pack_overvoltage_protection_binary_sensor) {
+    pack_overvoltage_protection_binary_sensor_ = pack_overvoltage_protection_binary_sensor;
+  }
+  void set_pack_undervoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *pack_undervoltage_protection_binary_sensor) {
+    pack_undervoltage_protection_binary_sensor_ = pack_undervoltage_protection_binary_sensor;
+  }
+  void set_charge_overtemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *charge_overtemperature_protection_binary_sensor) {
+    charge_overtemperature_protection_binary_sensor_ = charge_overtemperature_protection_binary_sensor;
+  }
+  void set_charge_undertemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *charge_undertemperature_protection_binary_sensor) {
+    charge_undertemperature_protection_binary_sensor_ = charge_undertemperature_protection_binary_sensor;
+  }
+  void set_discharge_overtemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *discharge_overtemperature_protection_binary_sensor) {
+    discharge_overtemperature_protection_binary_sensor_ = discharge_overtemperature_protection_binary_sensor;
+  }
+  void set_discharge_undertemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *discharge_undertemperature_protection_binary_sensor) {
+    discharge_undertemperature_protection_binary_sensor_ = discharge_undertemperature_protection_binary_sensor;
+  }
+  void set_charge_overcurrent_protection_binary_sensor(
+      binary_sensor::BinarySensor *charge_overcurrent_protection_binary_sensor) {
+    charge_overcurrent_protection_binary_sensor_ = charge_overcurrent_protection_binary_sensor;
+  }
+  void set_discharge_overcurrent_protection_binary_sensor(
+      binary_sensor::BinarySensor *discharge_overcurrent_protection_binary_sensor) {
+    discharge_overcurrent_protection_binary_sensor_ = discharge_overcurrent_protection_binary_sensor;
+  }
+  void set_short_circuit_protection_binary_sensor(binary_sensor::BinarySensor *short_circuit_protection_binary_sensor) {
+    short_circuit_protection_binary_sensor_ = short_circuit_protection_binary_sensor;
+  }
+  void set_ic_frontend_error_binary_sensor(binary_sensor::BinarySensor *ic_frontend_error_binary_sensor) {
+    ic_frontend_error_binary_sensor_ = ic_frontend_error_binary_sensor;
+  }
+  void set_mosfet_software_lock_binary_sensor(binary_sensor::BinarySensor *mosfet_software_lock_binary_sensor) {
+    mosfet_software_lock_binary_sensor_ = mosfet_software_lock_binary_sensor;
+  }
 
   void set_read_eeprom_register_select(select::Select *read_eeprom_register_select) {
     read_eeprom_register_select_ = read_eeprom_register_select;
@@ -159,6 +208,19 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *cell_overvoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *cell_undervoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *pack_overvoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *pack_undervoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *charge_overtemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *charge_undertemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *discharge_overtemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *discharge_undertemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *charge_overcurrent_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *discharge_overcurrent_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *short_circuit_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *ic_frontend_error_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *mosfet_software_lock_binary_sensor_{nullptr};
 
   select::Select *read_eeprom_register_select_{nullptr};
 
@@ -217,7 +279,6 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   // Cycle life
   // Production date
   // Balance status bitmask (32 Bits)
-  // Protection status bitmask (16 Bits)
   // Version
 
   std::string device_model_{};

--- a/components/jbd_bms_ble/binary_sensor.py
+++ b/components/jbd_bms_ble/binary_sensor.py
@@ -1,7 +1,11 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import (
+    DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_PROBLEM,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
 
 from . import CONF_JBD_BMS_BLE_ID, JBD_BMS_BLE_COMPONENT_SCHEMA
 from .const import CONF_CHARGING, CONF_DISCHARGING
@@ -12,40 +16,104 @@ CODEOWNERS = ["@syssi"]
 
 CONF_BALANCING = "balancing"
 CONF_ONLINE_STATUS = "online_status"
+CONF_CELL_OVERVOLTAGE_PROTECTION = "cell_overvoltage_protection"
+CONF_CELL_UNDERVOLTAGE_PROTECTION = "cell_undervoltage_protection"
+CONF_PACK_OVERVOLTAGE_PROTECTION = "pack_overvoltage_protection"
+CONF_PACK_UNDERVOLTAGE_PROTECTION = "pack_undervoltage_protection"
+CONF_CHARGE_OVERTEMPERATURE_PROTECTION = "charge_overtemperature_protection"
+CONF_CHARGE_UNDERTEMPERATURE_PROTECTION = "charge_undertemperature_protection"
+CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION = "discharge_overtemperature_protection"
+CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION = "discharge_undertemperature_protection"
+CONF_CHARGE_OVERCURRENT_PROTECTION = "charge_overcurrent_protection"
+CONF_DISCHARGE_OVERCURRENT_PROTECTION = "discharge_overcurrent_protection"
+CONF_SHORT_CIRCUIT_PROTECTION = "short_circuit_protection"
+CONF_IC_FRONTEND_ERROR = "ic_frontend_error"
+CONF_MOSFET_SOFTWARE_LOCK = "mosfet_software_lock"
 
 ICON_CHARGING = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
 ICON_BALANCING = "mdi:battery-heart-variant"
 
-BINARY_SENSORS = [
-    CONF_CHARGING,
-    CONF_DISCHARGING,
-    CONF_BALANCING,
-    CONF_ONLINE_STATUS,
-]
+# key: binary_sensor_schema kwargs
+BINARY_SENSOR_DEFS = {
+    CONF_CHARGING: {
+        "icon": ICON_CHARGING,
+    },
+    CONF_DISCHARGING: {
+        "icon": ICON_DISCHARGING,
+    },
+    CONF_BALANCING: {
+        "icon": ICON_BALANCING,
+    },
+    CONF_ONLINE_STATUS: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CELL_OVERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CELL_UNDERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_PACK_OVERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_PACK_UNDERVOLTAGE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGE_OVERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGE_UNDERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGE_OVERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGE_UNDERTEMPERATURE_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGE_OVERCURRENT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGE_OVERCURRENT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_SHORT_CIRCUIT_PROTECTION: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_IC_FRONTEND_ERROR: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_MOSFET_SOFTWARE_LOCK: {
+        "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+}
 
 CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            icon=ICON_CHARGING
-        ),
-        cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            icon=ICON_DISCHARGING
-        ),
-        cv.Optional(CONF_BALANCING): binary_sensor.binary_sensor_schema(
-            icon=ICON_BALANCING
-        ),
-        cv.Optional(CONF_ONLINE_STATUS): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_CONNECTIVITY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_JBD_BMS_BLE_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -560,6 +560,19 @@ void JbdBmsBle::on_hardware_info_data_(const std::vector<uint8_t> &data) {
   uint16_t errors_bitmask = jbd_get_16bit(16);
   this->publish_state_(this->errors_bitmask_sensor_, (float) errors_bitmask);
   this->publish_state_(this->errors_text_sensor_, this->bitmask_to_string_(ERRORS, ERRORS_SIZE, errors_bitmask));
+  this->publish_state_(this->cell_overvoltage_protection_binary_sensor_, errors_bitmask & (1 << 0));
+  this->publish_state_(this->cell_undervoltage_protection_binary_sensor_, errors_bitmask & (1 << 1));
+  this->publish_state_(this->pack_overvoltage_protection_binary_sensor_, errors_bitmask & (1 << 2));
+  this->publish_state_(this->pack_undervoltage_protection_binary_sensor_, errors_bitmask & (1 << 3));
+  this->publish_state_(this->charge_overtemperature_protection_binary_sensor_, errors_bitmask & (1 << 4));
+  this->publish_state_(this->charge_undertemperature_protection_binary_sensor_, errors_bitmask & (1 << 5));
+  this->publish_state_(this->discharge_overtemperature_protection_binary_sensor_, errors_bitmask & (1 << 6));
+  this->publish_state_(this->discharge_undertemperature_protection_binary_sensor_, errors_bitmask & (1 << 7));
+  this->publish_state_(this->charge_overcurrent_protection_binary_sensor_, errors_bitmask & (1 << 8));
+  this->publish_state_(this->discharge_overcurrent_protection_binary_sensor_, errors_bitmask & (1 << 9));
+  this->publish_state_(this->short_circuit_protection_binary_sensor_, errors_bitmask & (1 << 10));
+  this->publish_state_(this->ic_frontend_error_binary_sensor_, errors_bitmask & (1 << 11));
+  this->publish_state_(this->mosfet_software_lock_binary_sensor_, errors_bitmask & (1 << 12));
 
   // 18    1   0x80                   Version                                      0x10 = 1.0, 0x80 = 8.0
   this->publish_state_(this->software_version_sensor_, (data[18] >> 4) + ((data[18] & 0x0f) * 0.1f));
@@ -691,6 +704,21 @@ void JbdBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Online status", this->online_status_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Cell overvoltage protection", this->cell_overvoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Cell undervoltage protection", this->cell_undervoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Pack overvoltage protection", this->pack_overvoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Pack undervoltage protection", this->pack_undervoltage_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charge overtemperature protection", this->charge_overtemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charge undertemperature protection", this->charge_undertemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharge overtemperature protection",
+                    this->discharge_overtemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharge undertemperature protection",
+                    this->discharge_undertemperature_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Charge overcurrent protection", this->charge_overcurrent_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Discharge overcurrent protection", this->discharge_overcurrent_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Short circuit protection", this->short_circuit_protection_binary_sensor_);
+  LOG_BINARY_SENSOR("", "IC front-end error", this->ic_frontend_error_binary_sensor_);
+  LOG_BINARY_SENSOR("", "Mosfet Software Lock", this->mosfet_software_lock_binary_sensor_);
 
   LOG_SENSOR("", "Total voltage", this->total_voltage_sensor_);
   LOG_SENSOR("", "Battery strings", this->battery_strings_sensor_);

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -42,6 +42,55 @@ class JbdBmsBle :
   void set_online_status_binary_sensor(binary_sensor::BinarySensor *online_status_binary_sensor) {
     online_status_binary_sensor_ = online_status_binary_sensor;
   }
+  void set_cell_overvoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *cell_overvoltage_protection_binary_sensor) {
+    cell_overvoltage_protection_binary_sensor_ = cell_overvoltage_protection_binary_sensor;
+  }
+  void set_cell_undervoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *cell_undervoltage_protection_binary_sensor) {
+    cell_undervoltage_protection_binary_sensor_ = cell_undervoltage_protection_binary_sensor;
+  }
+  void set_pack_overvoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *pack_overvoltage_protection_binary_sensor) {
+    pack_overvoltage_protection_binary_sensor_ = pack_overvoltage_protection_binary_sensor;
+  }
+  void set_pack_undervoltage_protection_binary_sensor(
+      binary_sensor::BinarySensor *pack_undervoltage_protection_binary_sensor) {
+    pack_undervoltage_protection_binary_sensor_ = pack_undervoltage_protection_binary_sensor;
+  }
+  void set_charge_overtemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *charge_overtemperature_protection_binary_sensor) {
+    charge_overtemperature_protection_binary_sensor_ = charge_overtemperature_protection_binary_sensor;
+  }
+  void set_charge_undertemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *charge_undertemperature_protection_binary_sensor) {
+    charge_undertemperature_protection_binary_sensor_ = charge_undertemperature_protection_binary_sensor;
+  }
+  void set_discharge_overtemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *discharge_overtemperature_protection_binary_sensor) {
+    discharge_overtemperature_protection_binary_sensor_ = discharge_overtemperature_protection_binary_sensor;
+  }
+  void set_discharge_undertemperature_protection_binary_sensor(
+      binary_sensor::BinarySensor *discharge_undertemperature_protection_binary_sensor) {
+    discharge_undertemperature_protection_binary_sensor_ = discharge_undertemperature_protection_binary_sensor;
+  }
+  void set_charge_overcurrent_protection_binary_sensor(
+      binary_sensor::BinarySensor *charge_overcurrent_protection_binary_sensor) {
+    charge_overcurrent_protection_binary_sensor_ = charge_overcurrent_protection_binary_sensor;
+  }
+  void set_discharge_overcurrent_protection_binary_sensor(
+      binary_sensor::BinarySensor *discharge_overcurrent_protection_binary_sensor) {
+    discharge_overcurrent_protection_binary_sensor_ = discharge_overcurrent_protection_binary_sensor;
+  }
+  void set_short_circuit_protection_binary_sensor(binary_sensor::BinarySensor *short_circuit_protection_binary_sensor) {
+    short_circuit_protection_binary_sensor_ = short_circuit_protection_binary_sensor;
+  }
+  void set_ic_frontend_error_binary_sensor(binary_sensor::BinarySensor *ic_frontend_error_binary_sensor) {
+    ic_frontend_error_binary_sensor_ = ic_frontend_error_binary_sensor;
+  }
+  void set_mosfet_software_lock_binary_sensor(binary_sensor::BinarySensor *mosfet_software_lock_binary_sensor) {
+    mosfet_software_lock_binary_sensor_ = mosfet_software_lock_binary_sensor;
+  }
 
   void set_read_eeprom_register_select(select::Select *read_eeprom_register_select) {
     read_eeprom_register_select_ = read_eeprom_register_select;
@@ -176,6 +225,19 @@ class JbdBmsBle :
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *cell_overvoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *cell_undervoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *pack_overvoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *pack_undervoltage_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *charge_overtemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *charge_undertemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *discharge_overtemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *discharge_undertemperature_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *charge_overcurrent_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *discharge_overcurrent_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *short_circuit_protection_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *ic_frontend_error_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *mosfet_software_lock_binary_sensor_{nullptr};
 
   select::Select *read_eeprom_register_select_{nullptr};
 
@@ -234,7 +296,6 @@ class JbdBmsBle :
   // Cycle life
   // Production date
   // Balance status bitmask (32 Bits)
-  // Protection status bitmask (16 Bits)
   // Version
 
   std::vector<uint8_t> frame_buffer_;

--- a/docs/missing-features-plan.md
+++ b/docs/missing-features-plan.md
@@ -1,0 +1,185 @@
+# Missing Features: ESPHome vs Android App
+
+Analysis based on:
+- GitHub issue [#196](https://github.com/syssi/esphome-jbd-bms/issues/196)
+- Decompiled Android app v3.2.035 (`BMSBaseInfoCMDEntity.java`)
+- Current ESPHome implementation (`jbd_bms.cpp`, `jbd_bms.h`)
+
+---
+
+## Register 0x03 Frame Layout (Reference)
+
+```
+Byte  Len  Content
+ 0     2   Total voltage       ÷100    V
+ 2     2   Current             ÷100    A  (signed)
+ 4     2   Remaining capacity  ÷100    Ah
+ 6     2   Nominal capacity    ÷100    Ah
+ 8     2   Cycle count
+10     2   Production date     (packed: year-9 | month-4 | day-5)
+12     4   Balance status      (bitmask, 1 bit per cell)
+16     2   Protection status   (bitmask, see table below)
+18     1   Software version    (hi-nibble.lo-nibble)
+19     1   State of charge     %
+20     1   FET state           (bit 0 = charge, bit 1 = discharge)
+21     1   Cell count
+22     1   NTC sensor count
+23     n*2 NTC temperatures    (value - 2731) ÷ 10    °C
+```
+
+### Extended frame (newer firmware only)
+
+Present when `frame_len > (ntcNum * 2) + 22 + 5`:
+
+```
+Offset       Len  Content
+ntcNum*2+23   1   Mode flag       0x88 = high-resolution mode
+ntcNum*2+24   2   Alarm bitmask   (meaning TBD)
+ntcNum*2+26   2   Learned capacity ÷100   Ah
+ntcNum*2+28   2   Balance current  ÷100   A
+```
+
+**High-resolution mode:** When the mode flag byte equals `0x88` (136), current and
+remaining capacity use `÷10` instead of `÷100`.
+
+---
+
+## Protection Status Bitmask (Bytes 16–17)
+
+The app's `formatProtectionState()` iterates 13 bits across both bytes.
+Bit order: `byte[1]` holds bits 0–7, `byte[0]` holds bits 8–12.
+
+| Bit | Byte  | Mask | Name |
+|-----|-------|------|------|
+|  0  | [1]   | 0x0001 | Cell overvoltage |
+|  1  | [1]   | 0x0002 | Cell undervoltage |
+|  2  | [1]   | 0x0004 | Pack overvoltage |
+|  3  | [1]   | 0x0008 | Pack undervoltage |
+|  4  | [1]   | 0x0010 | Charge overtemperature |
+|  5  | [1]   | 0x0020 | Charge undertemperature |
+|  6  | [1]   | 0x0040 | Discharge overtemperature |
+|  7  | [1]   | 0x0080 | Discharge undertemperature |
+|  8  | [0]   | 0x0100 | Charge overcurrent |
+|  9  | [0]   | 0x0200 | Discharge overcurrent |
+| 10  | [0]   | 0x0400 | Short circuit |
+| 11  | [0]   | 0x0800 | IC front-end error |
+| 12  | [0]   | 0x1000 | Software MOS lock |
+| 13  | [0]   | 0x2000 | Charge timeout (ESPHome only, not in app) |
+
+ESPHome currently reads the raw 16-bit value into `errors_bitmask_sensor_` and
+formats all set bits into `errors_text_sensor_`. Individual binary sensors per
+protection bit are absent.
+
+---
+
+## Balance Status Bitmask (Bytes 12–15)
+
+The app's `formatBalanceStates()` maps 32 bits to a per-cell boolean array using
+this byte-to-cell mapping:
+
+| Cells   | Source byte |
+|---------|-------------|
+|  0–7    | byte[1] |
+|  8–15   | byte[0] |
+| 16–23   | byte[3] |
+| 24–31   | byte[2] |
+
+ESPHome reads the raw 32-bit value into `balancer_status_bitmask_sensor_` and
+derives one global `balancing_binary_sensor_`. Individual per-cell balance
+binary sensors are absent.
+
+---
+
+## Missing Features
+
+### 1. Protection Status Binary Sensors — Issue #196
+
+**Priority: High**
+
+The app exposes each protection bit individually in the main dashboard UI
+(`tvNowprotectionname`, `mProtectStatus`). ESPHome only provides the raw
+bitmask and a combined text sensor.
+
+**What to add** (both `jbd_bms` and `jbd_bms_ble` components):
+- 13 optional binary sensors, one per protection bit (see table above)
+- Names: `cell_overvoltage_protection`, `cell_undervoltage_protection`,
+  `pack_overvoltage_protection`, `pack_undervoltage_protection`,
+  `charge_overtemperature_protection`, `charge_undertemperature_protection`,
+  `discharge_overtemperature_protection`, `discharge_undertemperature_protection`,
+  `charge_overcurrent_protection`, `discharge_overcurrent_protection`,
+  `short_circuit_protection`, `ic_frontend_error`, `software_lock_mos`
+- Source: `errors_bitmask` bits 0–12, already parsed in `on_hardware_info_data_`
+- Suggested `entity_category`: `diagnostic`
+
+**Implementation notes:**
+- Data already read at line 321 (`uint16_t errors_bitmask`), no new BMS commands needed
+- Add sensors to `jbd_bms.h` and `jbd_bms.cpp` alongside the existing
+  `errors_bitmask_sensor_` and `errors_text_sensor_`
+- Same change applies identically to `jbd_bms_ble`
+
+---
+
+### 2. Production Date Text Sensor
+
+**Priority: Medium**
+
+**App behavior:** `formatProductDate(int i)` → `((i >> 9) + 2000) + "-" + ((i >> 5) & 15) + "-" + (i & 31)`
+
+**Current ESPHome behavior:** Bytes 10–11 are decoded at line 310–312 of
+`jbd_bms.cpp` and logged via `ESP_LOGD` only. No sensor is published.
+
+**What to add:**
+- `production_date` text sensor (entity_category: diagnostic)
+- Format: `"YYYY-MM-DD"` (zero-padded month/day for consistency)
+- Source: `jbd_get_16bit(10)`, already read
+
+---
+
+### 3. Extended Frame Fields (Newer Firmware)
+
+**Priority: Medium**
+
+Some BMS units return an extended 0x03 frame with additional bytes after the
+NTC temperatures. The app detects this via `content.length > (ntcNum * 2) + 22 + 5`.
+
+**What to add:**
+
+| Sensor | Type | Unit | Notes |
+|--------|------|------|-------|
+| `learned_capacity` | sensor | Ah | Measured/calibrated capacity |
+| `balance_current` | sensor | A | Current through balance resistors |
+| `alarm_bitmask` | sensor | — | Raw alarm bitmask, meaning TBD |
+
+**High-resolution current mode** (same frame):
+- When mode flag byte == `0x88`, the BMS reports current with `÷10` resolution
+  instead of `÷100`
+- ESPHome currently always uses `÷100` → values would be 10× too small on
+  affected devices
+- Fix: check `content[ntcNum * 2 + 23] == 0x88` and adjust divisors accordingly
+
+---
+
+### 4. Per-Cell Balance State Binary Sensors
+
+**Priority: Low** (raw bitmask already available via `balancer_status_bitmask`)
+
+**App behavior:** `balanceStates[N]` — one boolean per cell, shown per-cell in
+the voltage table.
+
+**What to add:**
+- Up to 32 optional binary sensors `balance_active_1` … `balance_active_32`,
+  structured the same as `cell_voltage_1` … `cell_voltage_32`
+- Derived from existing `balance_status_bitmask` (32-bit), using the byte-to-cell
+  mapping described above
+
+---
+
+## Summary Table
+
+| # | Feature | Priority | New sensors | Data source | Effort |
+|---|---------|----------|-------------|-------------|--------|
+| 1 | Protection status binary sensors | **High** | 13 binary sensors | Byte 16–17, already read | Low — no new parsing |
+| 2 | Production date text sensor | Medium | 1 text sensor | Byte 10–11, already read | Low — no new parsing |
+| 3 | Extended frame fields | Medium | 2–3 sensors | Bytes after NTC data | Medium — new parsing + detection |
+| 4 | High-resolution current mode | Medium | — (corrects existing sensors) | Mode flag byte | Low — conditional divisor |
+| 5 | Per-cell balance binary sensors | Low | Up to 32 binary sensors | Bytes 12–15, already read | Medium — new sensor array |

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -112,6 +112,45 @@ binary_sensor:
     online_status:
       name: "online status"
       device_id: device0
+    cell_overvoltage_protection:
+      name: "cell overvoltage protection"
+      device_id: device0
+    cell_undervoltage_protection:
+      name: "cell undervoltage protection"
+      device_id: device0
+    pack_overvoltage_protection:
+      name: "pack overvoltage protection"
+      device_id: device0
+    pack_undervoltage_protection:
+      name: "pack undervoltage protection"
+      device_id: device0
+    charge_overtemperature_protection:
+      name: "charge overtemperature protection"
+      device_id: device0
+    charge_undertemperature_protection:
+      name: "charge undertemperature protection"
+      device_id: device0
+    discharge_overtemperature_protection:
+      name: "discharge overtemperature protection"
+      device_id: device0
+    discharge_undertemperature_protection:
+      name: "discharge undertemperature protection"
+      device_id: device0
+    charge_overcurrent_protection:
+      name: "charge overcurrent protection"
+      device_id: device0
+    discharge_overcurrent_protection:
+      name: "discharge overcurrent protection"
+      device_id: device0
+    short_circuit_protection:
+      name: "short circuit protection"
+      device_id: device0
+    ic_frontend_error:
+      name: "ic frontend error"
+      device_id: device0
+    mosfet_software_lock:
+      name: "Mosfet Software Lock"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
@@ -126,6 +165,45 @@ binary_sensor:
       device_id: device1
     online_status:
       name: "online status"
+      device_id: device1
+    cell_overvoltage_protection:
+      name: "cell overvoltage protection"
+      device_id: device1
+    cell_undervoltage_protection:
+      name: "cell undervoltage protection"
+      device_id: device1
+    pack_overvoltage_protection:
+      name: "pack overvoltage protection"
+      device_id: device1
+    pack_undervoltage_protection:
+      name: "pack undervoltage protection"
+      device_id: device1
+    charge_overtemperature_protection:
+      name: "charge overtemperature protection"
+      device_id: device1
+    charge_undertemperature_protection:
+      name: "charge undertemperature protection"
+      device_id: device1
+    discharge_overtemperature_protection:
+      name: "discharge overtemperature protection"
+      device_id: device1
+    discharge_undertemperature_protection:
+      name: "discharge undertemperature protection"
+      device_id: device1
+    charge_overcurrent_protection:
+      name: "charge overcurrent protection"
+      device_id: device1
+    discharge_overcurrent_protection:
+      name: "discharge overcurrent protection"
+      device_id: device1
+    short_circuit_protection:
+      name: "short circuit protection"
+      device_id: device1
+    ic_frontend_error:
+      name: "ic frontend error"
+      device_id: device1
+    mosfet_software_lock:
+      name: "Mosfet Software Lock"
       device_id: device1
 
 sensor:

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -149,7 +149,7 @@ binary_sensor:
       name: "ic frontend error"
       device_id: device0
     mosfet_software_lock:
-      name: "Mosfet Software Lock"
+      name: "mosfet software lock"
       device_id: device0
 
   - platform: jbd_bms_ble
@@ -203,7 +203,7 @@ binary_sensor:
       name: "ic frontend error"
       device_id: device1
     mosfet_software_lock:
-      name: "Mosfet Software Lock"
+      name: "mosfet software lock"
       device_id: device1
 
 sensor:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -129,7 +129,7 @@ binary_sensor:
     ic_frontend_error:
       name: "ic frontend error"
     mosfet_software_lock:
-      name: "Mosfet Software Lock"
+      name: "mosfet software lock"
 
 sensor:
   - platform: jbd_bms_ble

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -104,6 +104,32 @@ binary_sensor:
       name: "discharging"
     online_status:
       name: "online status"
+    cell_overvoltage_protection:
+      name: "cell overvoltage protection"
+    cell_undervoltage_protection:
+      name: "cell undervoltage protection"
+    pack_overvoltage_protection:
+      name: "pack overvoltage protection"
+    pack_undervoltage_protection:
+      name: "pack undervoltage protection"
+    charge_overtemperature_protection:
+      name: "charge overtemperature protection"
+    charge_undertemperature_protection:
+      name: "charge undertemperature protection"
+    discharge_overtemperature_protection:
+      name: "discharge overtemperature protection"
+    discharge_undertemperature_protection:
+      name: "discharge undertemperature protection"
+    charge_overcurrent_protection:
+      name: "charge overcurrent protection"
+    discharge_overcurrent_protection:
+      name: "discharge overcurrent protection"
+    short_circuit_protection:
+      name: "short circuit protection"
+    ic_frontend_error:
+      name: "ic frontend error"
+    mosfet_software_lock:
+      name: "Mosfet Software Lock"
 
 sensor:
   - platform: jbd_bms_ble

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -123,7 +123,7 @@ binary_sensor:
     ic_frontend_error:
       name: "ic frontend error"
     mosfet_software_lock:
-      name: "Mosfet Software Lock"
+      name: "mosfet software lock"
 
 sensor:
   - platform: jbd_bms

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -98,6 +98,32 @@ binary_sensor:
       name: "discharging"
     online_status:
       name: "online status"
+    cell_overvoltage_protection:
+      name: "cell overvoltage protection"
+    cell_undervoltage_protection:
+      name: "cell undervoltage protection"
+    pack_overvoltage_protection:
+      name: "pack overvoltage protection"
+    pack_undervoltage_protection:
+      name: "pack undervoltage protection"
+    charge_overtemperature_protection:
+      name: "charge overtemperature protection"
+    charge_undertemperature_protection:
+      name: "charge undertemperature protection"
+    discharge_overtemperature_protection:
+      name: "discharge overtemperature protection"
+    discharge_undertemperature_protection:
+      name: "discharge undertemperature protection"
+    charge_overcurrent_protection:
+      name: "charge overcurrent protection"
+    discharge_overcurrent_protection:
+      name: "discharge overcurrent protection"
+    short_circuit_protection:
+      name: "short circuit protection"
+    ic_frontend_error:
+      name: "ic frontend error"
+    mosfet_software_lock:
+      name: "Mosfet Software Lock"
 
 sensor:
   - platform: jbd_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -96,6 +96,32 @@ binary_sensor:
       name: "discharging"
     online_status:
       name: "online status"
+    cell_overvoltage_protection:
+      name: "cell overvoltage protection"
+    cell_undervoltage_protection:
+      name: "cell undervoltage protection"
+    pack_overvoltage_protection:
+      name: "pack overvoltage protection"
+    pack_undervoltage_protection:
+      name: "pack undervoltage protection"
+    charge_overtemperature_protection:
+      name: "charge overtemperature protection"
+    charge_undertemperature_protection:
+      name: "charge undertemperature protection"
+    discharge_overtemperature_protection:
+      name: "discharge overtemperature protection"
+    discharge_undertemperature_protection:
+      name: "discharge undertemperature protection"
+    charge_overcurrent_protection:
+      name: "charge overcurrent protection"
+    discharge_overcurrent_protection:
+      name: "discharge overcurrent protection"
+    short_circuit_protection:
+      name: "short circuit protection"
+    ic_frontend_error:
+      name: "ic frontend error"
+    mosfet_software_lock:
+      name: "Mosfet Software Lock"
 
 sensor:
   - platform: jbd_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -121,7 +121,7 @@ binary_sensor:
     ic_frontend_error:
       name: "ic frontend error"
     mosfet_software_lock:
-      name: "Mosfet Software Lock"
+      name: "mosfet software lock"
 
 sensor:
   - platform: jbd_bms

--- a/tests/components/jbd_bms/frames.h
+++ b/tests/components/jbd_bms/frames.h
@@ -46,4 +46,39 @@ static const std::vector<uint8_t> ERRCOUNT_FRAME = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 };
 
+// Source: real hardware capture (BLE log, jbd_bms_ble component).
+// 4S, 280 Ah, cell overvoltage protection active. Decoded key values:
+//   total_voltage: 14.28 V         current: 0.00 A
+//   capacity_remaining: 280.00 Ah  nominal_capacity: 280.00 Ah
+//   charging_cycles: 8             soc: 100 %
+//   balancer_status_bitmask: 0     errors_bitmask: 0x0001 → cell_overvoltage_protection
+//   software_version: 8.0          operation_status: 0x02 → "Discharging"
+//   battery_strings: 4             temperature_sensors: 3
+//   temperatures[0]: 21.5°C  [1]: 20.9°C  [2]: 20.4°C
+static const std::vector<uint8_t> HWINFO_FRAME_CELL_OVERVOLTAGE = {
+    0x05, 0x94, 0x00, 0x00, 0x6D, 0x60, 0x6D, 0x60, 0x00, 0x08, 0x2C, 0x7C, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x80, 0x64, 0x02, 0x04, 0x03, 0x0B, 0x82, 0x0B, 0x7C, 0x0B, 0x77,
+};
+
+// errors_bitmask = 0x1FFF → all 13 protection bits set
+// data[16]=0x1F, data[17]=0xFF
+static const std::vector<uint8_t> HWINFO_FRAME_ALL_PROTECTIONS = {
+    0x06, 0x18, 0x00, 0x00, 0x01, 0xF2, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
+    0x00, 0x1F, 0xFF, 0x80, 0x64, 0x03, 0x04, 0x03, 0x0B, 0x8B, 0x0B, 0x8A, 0x0B, 0x84,
+};
+
+// Source: real hardware capture (README.md example output).
+// 4S, 5 Ah, software MOS lock active. Decoded key values:
+//   total_voltage: 15.47 V         current: 0.00 A
+//   capacity_remaining: 4.93 Ah    nominal_capacity: 5.00 Ah
+//   charging_cycles: 0             soc: 99 %
+//   balancer_status_bitmask: 0     errors_bitmask: 0x1000 → mosfet_software_lock
+//   software_version: 8.0          operation_status: 0x02 → "Discharging"
+//   battery_strings: 4             temperature_sensors: 3
+//   temperatures[0]: 24.5°C  [1]: 24.2°C  [2]: 23.7°C
+static const std::vector<uint8_t> HWINFO_FRAME_MOSFET_SOFTWARE_LOCK = {
+    0x06, 0x0B, 0x00, 0x00, 0x01, 0xED, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
+    0x00, 0x10, 0x00, 0x80, 0x63, 0x02, 0x04, 0x03, 0x0B, 0xA0, 0x0B, 0x9D, 0x0B, 0x98,
+};
+
 }  // namespace esphome::jbd_bms::testing

--- a/tests/components/jbd_bms/jbd_bms_test.cpp
+++ b/tests/components/jbd_bms/jbd_bms_test.cpp
@@ -249,7 +249,7 @@ TEST(JbdBmsErrorCountsTest, ErrorCounts) {
 
 // ── Protection binary sensors ─────────────────────────────────────────────────
 
-TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_NoneActive) {
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsNoneActive) {
   TestableJbdBms bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);
@@ -283,7 +283,7 @@ TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_NoneActive) {
   EXPECT_FALSE(swl.state);
 }
 
-TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_CellOvervoltage) {
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsCellOvervoltage) {
   TestableJbdBms bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);
@@ -317,7 +317,7 @@ TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_CellOvervoltage) {
   EXPECT_FALSE(swl.state);
 }
 
-TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_AllActive) {
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsAllActive) {
   TestableJbdBms bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);
@@ -351,7 +351,7 @@ TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_AllActive) {
   EXPECT_TRUE(swl.state);
 }
 
-TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_ByteOrder) {
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsByteOrder) {
   TestableJbdBms bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);

--- a/tests/components/jbd_bms/jbd_bms_test.cpp
+++ b/tests/components/jbd_bms/jbd_bms_test.cpp
@@ -247,6 +247,144 @@ TEST(JbdBmsErrorCountsTest, ErrorCounts) {
   EXPECT_FLOAT_EQ(buv.state, 0.0f);
 }
 
+// ── Protection binary sensors ─────────────────────────────────────────────────
+
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_NoneActive) {
+  TestableJbdBms bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+
+  EXPECT_FALSE(cov.state);
+  EXPECT_FALSE(cuv.state);
+  EXPECT_FALSE(pov.state);
+  EXPECT_FALSE(puv.state);
+  EXPECT_FALSE(cot.state);
+  EXPECT_FALSE(cut.state);
+  EXPECT_FALSE(dot.state);
+  EXPECT_FALSE(dut.state);
+  EXPECT_FALSE(co.state);
+  EXPECT_FALSE(doc.state);
+  EXPECT_FALSE(sc.state);
+  EXPECT_FALSE(ic.state);
+  EXPECT_FALSE(swl.state);
+}
+
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_CellOvervoltage) {
+  TestableJbdBms bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_CELL_OVERVOLTAGE);
+
+  EXPECT_TRUE(cov.state);
+  EXPECT_FALSE(cuv.state);
+  EXPECT_FALSE(pov.state);
+  EXPECT_FALSE(puv.state);
+  EXPECT_FALSE(cot.state);
+  EXPECT_FALSE(cut.state);
+  EXPECT_FALSE(dot.state);
+  EXPECT_FALSE(dut.state);
+  EXPECT_FALSE(co.state);
+  EXPECT_FALSE(doc.state);
+  EXPECT_FALSE(sc.state);
+  EXPECT_FALSE(ic.state);
+  EXPECT_FALSE(swl.state);
+}
+
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_AllActive) {
+  TestableJbdBms bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_ALL_PROTECTIONS);
+
+  EXPECT_TRUE(cov.state);
+  EXPECT_TRUE(cuv.state);
+  EXPECT_TRUE(pov.state);
+  EXPECT_TRUE(puv.state);
+  EXPECT_TRUE(cot.state);
+  EXPECT_TRUE(cut.state);
+  EXPECT_TRUE(dot.state);
+  EXPECT_TRUE(dut.state);
+  EXPECT_TRUE(co.state);
+  EXPECT_TRUE(doc.state);
+  EXPECT_TRUE(sc.state);
+  EXPECT_TRUE(ic.state);
+  EXPECT_TRUE(swl.state);
+}
+
+TEST(JbdBmsHwInfoTest, ProtectionBinarySensors_ByteOrder) {
+  TestableJbdBms bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_MOSFET_SOFTWARE_LOCK);
+
+  EXPECT_FALSE(cov.state);
+  EXPECT_FALSE(cuv.state);
+  EXPECT_FALSE(pov.state);
+  EXPECT_FALSE(puv.state);
+  EXPECT_FALSE(cot.state);
+  EXPECT_FALSE(cut.state);
+  EXPECT_FALSE(dot.state);
+  EXPECT_FALSE(dut.state);
+  EXPECT_FALSE(co.state);
+  EXPECT_FALSE(doc.state);
+  EXPECT_FALSE(sc.state);
+  EXPECT_FALSE(ic.state);
+  EXPECT_TRUE(swl.state);
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(JbdBmsTest, NullSensorsDoNotCrash) {

--- a/tests/components/jbd_bms_ble/frames.h
+++ b/tests/components/jbd_bms_ble/frames.h
@@ -46,4 +46,39 @@ static const std::vector<uint8_t> ERRCOUNT_FRAME = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 };
 
+// Source: real hardware capture (BLE log, jbd_bms_ble component).
+// 4S, 280 Ah, cell overvoltage protection active. Decoded key values:
+//   total_voltage: 14.28 V         current: 0.00 A
+//   capacity_remaining: 280.00 Ah  nominal_capacity: 280.00 Ah
+//   charging_cycles: 8             soc: 100 %
+//   balancer_status_bitmask: 0     errors_bitmask: 0x0001 → cell_overvoltage_protection
+//   software_version: 8.0          operation_status: 0x02 → "Discharging"
+//   battery_strings: 4             temperature_sensors: 3
+//   temperatures[0]: 21.5°C  [1]: 20.9°C  [2]: 20.4°C
+static const std::vector<uint8_t> HWINFO_FRAME_CELL_OVERVOLTAGE = {
+    0x05, 0x94, 0x00, 0x00, 0x6D, 0x60, 0x6D, 0x60, 0x00, 0x08, 0x2C, 0x7C, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x80, 0x64, 0x02, 0x04, 0x03, 0x0B, 0x82, 0x0B, 0x7C, 0x0B, 0x77,
+};
+
+// errors_bitmask = 0x1FFF → all 13 protection bits set
+// data[16]=0x1F, data[17]=0xFF
+static const std::vector<uint8_t> HWINFO_FRAME_ALL_PROTECTIONS = {
+    0x06, 0x18, 0x00, 0x00, 0x01, 0xF2, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
+    0x00, 0x1F, 0xFF, 0x80, 0x64, 0x03, 0x04, 0x03, 0x0B, 0x8B, 0x0B, 0x8A, 0x0B, 0x84,
+};
+
+// Source: real hardware capture (README.md example output).
+// 4S, 5 Ah, software MOS lock active. Decoded key values:
+//   total_voltage: 15.47 V         current: 0.00 A
+//   capacity_remaining: 4.93 Ah    nominal_capacity: 5.00 Ah
+//   charging_cycles: 0             soc: 99 %
+//   balancer_status_bitmask: 0     errors_bitmask: 0x1000 → mosfet_software_lock
+//   software_version: 8.0          operation_status: 0x02 → "Discharging"
+//   battery_strings: 4             temperature_sensors: 3
+//   temperatures[0]: 24.5°C  [1]: 24.2°C  [2]: 23.7°C
+static const std::vector<uint8_t> HWINFO_FRAME_MOSFET_SOFTWARE_LOCK = {
+    0x06, 0x0B, 0x00, 0x00, 0x01, 0xED, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
+    0x00, 0x10, 0x00, 0x80, 0x63, 0x02, 0x04, 0x03, 0x0B, 0xA0, 0x0B, 0x9D, 0x0B, 0x98,
+};
+
 }  // namespace esphome::jbd_bms_ble::testing

--- a/tests/components/jbd_bms_ble/jbd_bms_ble_test.cpp
+++ b/tests/components/jbd_bms_ble/jbd_bms_ble_test.cpp
@@ -249,7 +249,7 @@ TEST(JbdBmsBleErrorCountsTest, ErrorCounts) {
 
 // ── Protection binary sensors ─────────────────────────────────────────────────
 
-TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_NoneActive) {
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensorsNoneActive) {
   TestableJbdBmsBle bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);
@@ -283,7 +283,7 @@ TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_NoneActive) {
   EXPECT_FALSE(swl.state);
 }
 
-TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_CellOvervoltage) {
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensorsCellOvervoltage) {
   TestableJbdBmsBle bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);
@@ -317,7 +317,7 @@ TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_CellOvervoltage) {
   EXPECT_FALSE(swl.state);
 }
 
-TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_AllActive) {
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensorsAllActive) {
   TestableJbdBmsBle bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);
@@ -351,7 +351,7 @@ TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_AllActive) {
   EXPECT_TRUE(swl.state);
 }
 
-TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_ByteOrder) {
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensorsByteOrder) {
   TestableJbdBmsBle bms;
   binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
   bms.set_cell_overvoltage_protection_binary_sensor(&cov);

--- a/tests/components/jbd_bms_ble/jbd_bms_ble_test.cpp
+++ b/tests/components/jbd_bms_ble/jbd_bms_ble_test.cpp
@@ -247,6 +247,144 @@ TEST(JbdBmsBleErrorCountsTest, ErrorCounts) {
   EXPECT_FLOAT_EQ(buv.state, 0.0f);
 }
 
+// ── Protection binary sensors ─────────────────────────────────────────────────
+
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_NoneActive) {
+  TestableJbdBmsBle bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+
+  EXPECT_FALSE(cov.state);
+  EXPECT_FALSE(cuv.state);
+  EXPECT_FALSE(pov.state);
+  EXPECT_FALSE(puv.state);
+  EXPECT_FALSE(cot.state);
+  EXPECT_FALSE(cut.state);
+  EXPECT_FALSE(dot.state);
+  EXPECT_FALSE(dut.state);
+  EXPECT_FALSE(co.state);
+  EXPECT_FALSE(doc.state);
+  EXPECT_FALSE(sc.state);
+  EXPECT_FALSE(ic.state);
+  EXPECT_FALSE(swl.state);
+}
+
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_CellOvervoltage) {
+  TestableJbdBmsBle bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_CELL_OVERVOLTAGE);
+
+  EXPECT_TRUE(cov.state);
+  EXPECT_FALSE(cuv.state);
+  EXPECT_FALSE(pov.state);
+  EXPECT_FALSE(puv.state);
+  EXPECT_FALSE(cot.state);
+  EXPECT_FALSE(cut.state);
+  EXPECT_FALSE(dot.state);
+  EXPECT_FALSE(dut.state);
+  EXPECT_FALSE(co.state);
+  EXPECT_FALSE(doc.state);
+  EXPECT_FALSE(sc.state);
+  EXPECT_FALSE(ic.state);
+  EXPECT_FALSE(swl.state);
+}
+
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_AllActive) {
+  TestableJbdBmsBle bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_ALL_PROTECTIONS);
+
+  EXPECT_TRUE(cov.state);
+  EXPECT_TRUE(cuv.state);
+  EXPECT_TRUE(pov.state);
+  EXPECT_TRUE(puv.state);
+  EXPECT_TRUE(cot.state);
+  EXPECT_TRUE(cut.state);
+  EXPECT_TRUE(dot.state);
+  EXPECT_TRUE(dut.state);
+  EXPECT_TRUE(co.state);
+  EXPECT_TRUE(doc.state);
+  EXPECT_TRUE(sc.state);
+  EXPECT_TRUE(ic.state);
+  EXPECT_TRUE(swl.state);
+}
+
+TEST(JbdBmsBleHwInfoTest, ProtectionBinarySensors_ByteOrder) {
+  TestableJbdBmsBle bms;
+  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
+  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
+  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
+  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
+  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
+  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
+  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
+  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
+  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
+  bms.set_charge_overcurrent_protection_binary_sensor(&co);
+  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
+  bms.set_short_circuit_protection_binary_sensor(&sc);
+  bms.set_ic_frontend_error_binary_sensor(&ic);
+  bms.set_mosfet_software_lock_binary_sensor(&swl);
+
+  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_MOSFET_SOFTWARE_LOCK);
+
+  EXPECT_FALSE(cov.state);
+  EXPECT_FALSE(cuv.state);
+  EXPECT_FALSE(pov.state);
+  EXPECT_FALSE(puv.state);
+  EXPECT_FALSE(cot.state);
+  EXPECT_FALSE(cut.state);
+  EXPECT_FALSE(dot.state);
+  EXPECT_FALSE(dut.state);
+  EXPECT_FALSE(co.state);
+  EXPECT_FALSE(doc.state);
+  EXPECT_FALSE(sc.state);
+  EXPECT_FALSE(ic.state);
+  EXPECT_TRUE(swl.state);
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(JbdBmsBleTest, NullSensorsDoNotCrash) {

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -15,6 +15,7 @@ from components.jbd_bms import (  # noqa: E402  # noqa: E402
 )
 import components.jbd_bms_ble as hub_ble  # noqa: E402
 from components.jbd_bms_ble import (  # noqa: E402
+    binary_sensor as ble_binary_sensor,  # noqa: E402
     button as ble_button,  # noqa: E402
     sensor as ble_sensor,
     switch as ble_switch,  # noqa: E402
@@ -63,6 +64,23 @@ class TestSensorLists:
             assert key not in sensor.TEMPERATURES
 
 
+PROTECTION_KEYS = [
+    "cell_overvoltage_protection",
+    "cell_undervoltage_protection",
+    "pack_overvoltage_protection",
+    "pack_undervoltage_protection",
+    "charge_overtemperature_protection",
+    "charge_undertemperature_protection",
+    "discharge_overtemperature_protection",
+    "discharge_undertemperature_protection",
+    "charge_overcurrent_protection",
+    "discharge_overcurrent_protection",
+    "short_circuit_protection",
+    "ic_frontend_error",
+    "mosfet_software_lock",
+]
+
+
 class TestBinarySensorConstants:
     def test_binary_sensor_defs_dict(self):
         from components.jbd_bms.const import CONF_CHARGING, CONF_DISCHARGING
@@ -71,7 +89,30 @@ class TestBinarySensorConstants:
         assert CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_BALANCING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
-        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 4
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 17
+
+    def test_protection_sensors_in_defs(self):
+        for key in PROTECTION_KEYS:
+            assert (
+                key in binary_sensor.BINARY_SENSOR_DEFS
+            ), f"{key} missing from jbd_bms BINARY_SENSOR_DEFS"
+
+    def test_ble_binary_sensor_defs_dict(self):
+        from components.jbd_bms_ble.const import CONF_CHARGING, CONF_DISCHARGING
+
+        assert CONF_CHARGING in ble_binary_sensor.BINARY_SENSOR_DEFS
+        assert CONF_DISCHARGING in ble_binary_sensor.BINARY_SENSOR_DEFS
+        assert ble_binary_sensor.CONF_BALANCING in ble_binary_sensor.BINARY_SENSOR_DEFS
+        assert (
+            ble_binary_sensor.CONF_ONLINE_STATUS in ble_binary_sensor.BINARY_SENSOR_DEFS
+        )
+        assert len(ble_binary_sensor.BINARY_SENSOR_DEFS) == 17
+
+    def test_ble_protection_sensors_in_defs(self):
+        for key in PROTECTION_KEYS:
+            assert (
+                key in ble_binary_sensor.BINARY_SENSOR_DEFS
+            ), f"{key} missing from jbd_bms_ble BINARY_SENSOR_DEFS"
 
 
 class TestTextSensorConstants:


### PR DESCRIPTION
## Summary

- Exposes the 13 individual protection bits from the `errors_bitmask` (register `0x03`, bytes 16–17) as `DEVICE_CLASS_PROBLEM` / `ENTITY_CATEGORY_DIAGNOSTIC` binary sensors
- Implemented for both `jbd_bms` (UART) and `jbd_bms_ble` (BLE) components
- The raw bitmask was already parsed; only sensor publication and schema registration were missing

**New binary sensors:**
- `cell_overvoltage_protection` (bit 0)
- `cell_undervoltage_protection` (bit 1)
- `pack_overvoltage_protection` (bit 2)
- `pack_undervoltage_protection` (bit 3)
- `charge_overtemperature_protection` (bit 4)
- `charge_undertemperature_protection` (bit 5)
- `discharge_overtemperature_protection` (bit 6)
- `discharge_undertemperature_protection` (bit 7)
- `charge_overcurrent_protection` (bit 8)
- `discharge_overcurrent_protection` (bit 9)
- `short_circuit_protection` (bit 10)
- `ic_frontend_error` (bit 11)
- `mosfet_software_lock` (bit 12)

## Test plan

- [x] C++ unit tests: `ProtectionBinarySensors_NoneActive`, `ProtectionBinarySensors_AllActive`, `ProtectionBinarySensors_ByteOrder` for both `jbd_bms` and `jbd_bms_ble`
- [x] pytest schema tests: count assertions updated to 17, protection keys verified for both components
- [x] Example YAML configs updated with all 13 new sensors