### PR TITLE
Add tests for MOSFET switch write operations

### DIFF
--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -1,4 +1,5 @@
 #include "jbd_bms.h"
+#include <array>
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
@@ -595,26 +596,28 @@ bool JbdBms::change_mosfet_status(uint8_t address, uint8_t bitmask, bool state) 
   return this->write_register(address, value);
 }
 
+std::array<uint8_t, 9> JbdBms::build_frame_(uint8_t command, uint8_t address, uint16_t value) const {
+  std::array<uint8_t, 9> frame{};
+  frame[0] = JBD_PKT_START;
+  frame[1] = command;
+  frame[2] = address;
+  frame[3] = 0x02;
+  frame[4] = value >> 8;
+  frame[5] = value >> 0;
+  auto crc = chksum_(frame.data() + 2, 4);
+  frame[6] = crc >> 8;
+  frame[7] = crc >> 0;
+  frame[8] = JBD_PKT_END;
+  return frame;
+}
+
 bool JbdBms::write_register(uint8_t address, uint16_t value) {
   if (this->flow_control_pin_ != nullptr)
     this->flow_control_pin_->digital_write(true);
 
-  uint8_t frame[9];
-  uint8_t data_len = 2;
-
-  frame[0] = JBD_PKT_START;
-  frame[1] = JBD_CMD_WRITE;
-  frame[2] = address;
-  frame[3] = data_len;
-  frame[4] = value >> 8;
-  frame[5] = value >> 0;
-  auto crc = chksum_(frame + 2, data_len + 2);
-  frame[6] = crc >> 8;
-  frame[7] = crc >> 0;
-  frame[8] = JBD_PKT_END;
-
-  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(frame, sizeof(frame)).c_str());  // NOLINT
-  this->write_array(frame, 9);
+  auto frame = build_frame_(JBD_CMD_WRITE, address, value);
+  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
+  this->write_array(frame.data(), frame.size());
   this->flush();
 
   if (this->flow_control_pin_ != nullptr)

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/select/select.h"
@@ -202,7 +203,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
   virtual void send_command(uint8_t action, uint8_t function);
-  bool write_register(uint8_t address, uint16_t value);
+  virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
   void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
 
@@ -306,7 +307,9 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void track_online_status_();
   std::string bitmask_to_string_(const char *const messages[], const uint8_t &messages_size, const uint16_t &mask);
 
-  uint16_t chksum_(const uint8_t data[], const uint16_t len) {
+  std::array<uint8_t, 9> build_frame_(uint8_t command, uint8_t address, uint16_t value) const;
+
+  uint16_t chksum_(const uint8_t data[], const uint16_t len) const {
     uint16_t checksum = 0x00;
     for (uint16_t i = 0; i < len; i++) {
       checksum = checksum - data[i];

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -838,7 +838,21 @@ void JbdBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::
   text_sensor->publish_state(state);
 }
 
-#ifdef USE_ESP32
+std::array<uint8_t, 9> JbdBmsBle::build_frame_(uint8_t command, uint8_t address, uint16_t value) const {
+  std::array<uint8_t, 9> frame{};
+  frame[0] = JBD_PKT_START;
+  frame[1] = command;
+  frame[2] = address;
+  frame[3] = 0x02;
+  frame[4] = value >> 8;
+  frame[5] = value >> 0;
+  auto crc = chksum_(frame.data() + 2, 4);
+  frame[6] = crc >> 8;
+  frame[7] = crc >> 0;
+  frame[8] = JBD_PKT_END;
+  return frame;
+}
+
 bool JbdBmsBle::change_mosfet_status(uint8_t address, uint8_t bitmask, bool state) {
   if (this->mosfet_status_ == 255) {
     ESP_LOGE(TAG, "Unable to change the Mosfet status because it's unknown");
@@ -855,21 +869,7 @@ bool JbdBmsBle::change_mosfet_status(uint8_t address, uint8_t bitmask, bool stat
   return this->write_register(address, value);
 }
 
-std::array<uint8_t, 9> JbdBmsBle::build_frame_(uint8_t command, uint8_t address, uint16_t value) const {
-  std::array<uint8_t, 9> frame{};
-  frame[0] = JBD_PKT_START;
-  frame[1] = command;
-  frame[2] = address;
-  frame[3] = 0x02;
-  frame[4] = value >> 8;
-  frame[5] = value >> 0;
-  auto crc = chksum_(frame.data() + 2, 4);
-  frame[6] = crc >> 8;
-  frame[7] = crc >> 0;
-  frame[8] = JBD_PKT_END;
-  return frame;
-}
-
+#ifdef USE_ESP32
 bool JbdBmsBle::write_register(uint8_t address, uint16_t value) {
   auto frame = build_frame_(JBD_CMD_WRITE, address, value);
   ESP_LOGV(TAG, "Send command (handle 0x%02X): %s", this->char_command_handle_,
@@ -911,6 +911,7 @@ bool JbdBmsBle::send_command(uint8_t action, uint8_t function) {
   return (status == 0);
 }
 #else
+bool JbdBmsBle::write_register(uint8_t address, uint16_t value) { return false; }
 bool JbdBmsBle::send_command(uint8_t action, uint8_t function) { return false; }
 #endif  // USE_ESP32
 

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -1,4 +1,5 @@
 #include "jbd_bms_ble.h"
+#include <array>
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/version.h"
@@ -854,26 +855,28 @@ bool JbdBmsBle::change_mosfet_status(uint8_t address, uint8_t bitmask, bool stat
   return this->write_register(address, value);
 }
 
-bool JbdBmsBle::write_register(uint8_t address, uint16_t value) {
-  uint8_t frame[9];
-  uint8_t data_len = 2;
-
+std::array<uint8_t, 9> JbdBmsBle::build_frame_(uint8_t command, uint8_t address, uint16_t value) const {
+  std::array<uint8_t, 9> frame{};
   frame[0] = JBD_PKT_START;
-  frame[1] = JBD_CMD_WRITE;
+  frame[1] = command;
   frame[2] = address;
-  frame[3] = data_len;
+  frame[3] = 0x02;
   frame[4] = value >> 8;
   frame[5] = value >> 0;
-  auto crc = chksum_(frame + 2, data_len + 2);
+  auto crc = chksum_(frame.data() + 2, 4);
   frame[6] = crc >> 8;
   frame[7] = crc >> 0;
   frame[8] = JBD_PKT_END;
+  return frame;
+}
 
+bool JbdBmsBle::write_register(uint8_t address, uint16_t value) {
+  auto frame = build_frame_(JBD_CMD_WRITE, address, value);
   ESP_LOGV(TAG, "Send command (handle 0x%02X): %s", this->char_command_handle_,
-           format_hex_pretty(frame, sizeof(frame)).c_str());  // NOLINT
+           format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
   auto status =
       esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_command_handle_,
-                               sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+                               frame.size(), frame.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
 
   if (status) {
     ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", ADDR_STR(this->parent_->address_str()), status);

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/select/select.h"
@@ -218,7 +219,7 @@ class JbdBmsBle :
   void set_authentication_timeout(uint32_t timeout_ms) { auth_timeout_ms_ = timeout_ms; }
 
   bool send_command(uint8_t action, uint8_t function);
-  bool write_register(uint8_t address, uint16_t value);
+  virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
   void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
   void assemble(const uint8_t *data, uint16_t length);
@@ -321,7 +322,9 @@ class JbdBmsBle :
   void track_online_status_();
   std::string bitmask_to_string_(const char *const messages[], const uint8_t &messages_size, const uint16_t &mask);
 
-  uint16_t chksum_(const uint8_t data[], const uint16_t len) {
+  std::array<uint8_t, 9> build_frame_(uint8_t command, uint8_t address, uint16_t value) const;
+
+  uint16_t chksum_(const uint8_t data[], const uint16_t len) const {
     uint16_t checksum = 0x00;
     for (uint16_t i = 0; i < len; i++) {
       checksum = checksum - data[i];

--- a/tests/components/jbd_bms/common.h
+++ b/tests/components/jbd_bms/common.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstdint>
 #include <vector>
 #include "esphome/components/jbd_bms/jbd_bms.h"
@@ -10,6 +11,15 @@ class TestableJbdBms : public JbdBms {
  public:
   void update() override {}
   void send_command(uint8_t action, uint8_t function) override {}
+  void set_mosfet_status(uint8_t status) { this->mosfet_status_ = status; }
+  bool write_register(uint8_t address, uint16_t value) override {
+    last_write_address = address;
+    last_write_value = value;
+    return true;
+  }
+  using JbdBms::build_frame_;
+  uint8_t last_write_address{0};
+  uint16_t last_write_value{0};
 };
 
 class TestableSwitch : public switch_::Switch {

--- a/tests/components/jbd_bms/write_command_test.cpp
+++ b/tests/components/jbd_bms/write_command_test.cpp
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+#include <array>
+#include "common.h"
+
+namespace esphome::jbd_bms::testing {
+
+// JBD write frame layout (9 bytes):
+//   [0]    SOF         0xDD
+//   [1]    CMD_WRITE   0x5A
+//   [2]    address
+//   [3]    data_len    0x02
+//   [4]    value high
+//   [5]    value low
+//   [6]    CRC high
+//   [7]    CRC low
+//   [8]    EOF         0x77
+//
+// CRC = 0x10000 - sum(frame[2..5])   (two's complement, 16-bit)
+//
+// Physical PulseView captures (register 0xE1 = MOS control):
+//   Both ON  (0x0000): DD 5A E1 02 00 00 FF 1D 77   (initial state: charging+discharging enabled)
+//   Chg OFF  (0x0001): DD 5A E1 02 00 01 FF 1C 77
+//   Dsg OFF  (0x0002): DD 5A E1 02 00 02 FF 1B 77
+//   Both OFF (0x0003): DD 5A E1 02 00 03 FF 1A 77
+
+// ── Frame header / trailer ────────────────────────────────────────────────────
+
+TEST(WriteCommandTest, HeaderAndTrailer) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+
+  EXPECT_EQ(f[0], 0xDD);  // SOF
+  EXPECT_EQ(f[1], 0x5A);  // CMD_WRITE
+  EXPECT_EQ(f[3], 0x02);  // data length
+  EXPECT_EQ(f[8], 0x77);  // EOF
+}
+
+// ── CRC ───────────────────────────────────────────────────────────────────────
+
+TEST(WriteCommandTest, CrcBothEnabled) {
+  TestableJbdBms bms;
+  // sum(E1, 02, 00, 00) = 0xE3 → CRC = 0x10000 - 0xE3 = 0xFF1D
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  EXPECT_EQ(f[6], 0xFF);
+  EXPECT_EQ(f[7], 0x1D);
+}
+
+TEST(WriteCommandTest, CrcMatchesTwosComplement) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+
+  uint16_t sum = 0;
+  for (int i = 2; i <= 5; i++)
+    sum += f[i];
+  uint16_t expected = static_cast<uint16_t>(0x10000u - sum);
+
+  EXPECT_EQ(f[6], expected >> 8);
+  EXPECT_EQ(f[7], expected & 0xFF);
+}
+
+// ── Full frame comparisons against physical captures ─────────────────────────
+
+TEST(WriteCommandTest, FrameBothEnabled) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x00, 0xFF, 0x1D, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(WriteCommandTest, FrameChargingDisabled) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x01, 0xFF, 0x1C, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(WriteCommandTest, FrameDischargingDisabled) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0002);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x02, 0xFF, 0x1B, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(WriteCommandTest, FrameBothDisabled) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0003);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x03, 0xFF, 0x1A, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+// ── change_mosfet_status state transitions ───────────────────────────────────
+//
+// Register 0xE1 uses inverted encoding: bit set = DISABLED.
+// Internal mosfet_status_ bit layout: bit0=charging, bit1=discharging.
+// Wire encoding: bits XOR'd with 0x03 (both inverted).
+//
+// Initial state from hardware info frame: 0x03 = both enabled → wire value 0x00.
+
+TEST(MosfetSwitchTest, ChargingOffFromBothEnabled) {
+  TestableJbdBms bms;
+  bms.set_mosfet_status(0x03);  // charging=1, discharging=1
+  bms.change_mosfet_status(0xE1, 0, false);
+
+  // mosfet_status_ becomes 0x02 (discharging=1, charging=0)
+  // wire value: 0x02 XOR 0x03 = 0x01
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0001);
+}
+
+TEST(MosfetSwitchTest, DischargingOffFromBothEnabled) {
+  TestableJbdBms bms;
+  bms.set_mosfet_status(0x03);
+  bms.change_mosfet_status(0xE1, 1, false);
+
+  // mosfet_status_ becomes 0x01 (discharging=0, charging=1)
+  // wire value: 0x01 XOR 0x03 = 0x02
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0002);
+}
+
+TEST(MosfetSwitchTest, BothOffFromBothEnabled) {
+  TestableJbdBms bms;
+  bms.set_mosfet_status(0x03);
+  bms.change_mosfet_status(0xE1, 0, false);  // charging off → mosfet_status_=0x02
+  bms.change_mosfet_status(0xE1, 1, false);  // discharging off → mosfet_status_=0x00
+
+  // wire value: 0x00 XOR 0x03 = 0x03
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0003);
+}
+
+TEST(MosfetSwitchTest, ChargingOnFromBothDisabled) {
+  TestableJbdBms bms;
+  bms.set_mosfet_status(0x00);
+  bms.change_mosfet_status(0xE1, 0, true);
+
+  // mosfet_status_ becomes 0x01
+  // wire value: 0x01 XOR 0x03 = 0x02
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0002);
+}
+
+TEST(MosfetSwitchTest, UnknownStatusReturnsError) {
+  TestableJbdBms bms;
+  // mosfet_status_ defaults to 255 = unknown
+  bool result = bms.change_mosfet_status(0xE1, 0, false);
+  EXPECT_FALSE(result);
+}
+
+}  // namespace esphome::jbd_bms::testing

--- a/tests/components/jbd_bms_ble/common.h
+++ b/tests/components/jbd_bms_ble/common.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstdint>
 #include <vector>
 #include "esphome/components/jbd_bms_ble/jbd_bms_ble.h"
@@ -9,6 +10,15 @@ namespace esphome::jbd_bms_ble::testing {
 class TestableJbdBmsBle : public JbdBmsBle {
  public:
   void update() override {}
+  void set_mosfet_status(uint8_t status) { this->mosfet_status_ = status; }
+  bool write_register(uint8_t address, uint16_t value) override {
+    last_write_address = address;
+    last_write_value = value;
+    return true;
+  }
+  using JbdBmsBle::build_frame_;
+  uint8_t last_write_address{0};
+  uint16_t last_write_value{0};
 };
 
 class TestableSwitch : public switch_::Switch {

--- a/tests/components/jbd_bms_ble/write_command_test.cpp
+++ b/tests/components/jbd_bms_ble/write_command_test.cpp
@@ -1,0 +1,156 @@
+#include <gtest/gtest.h>
+#include <array>
+#include "common.h"
+
+namespace esphome::jbd_bms_ble::testing {
+
+// JBD write frame layout (9 bytes):
+//   [0]    SOF         0xDD
+//   [1]    CMD_WRITE   0x5A
+//   [2]    address
+//   [3]    data_len    0x02
+//   [4]    value high
+//   [5]    value low
+//   [6]    CRC high
+//   [7]    CRC low
+//   [8]    EOF         0x77
+//
+// CRC = 0x10000 - sum(frame[2..5])   (two's complement, 16-bit)
+//
+// Physical PulseView captures (register 0xE1 = MOS control):
+//   Both ON  (0x0000): DD 5A E1 02 00 00 FF 1D 77
+//   Chg OFF  (0x0001): DD 5A E1 02 00 01 FF 1C 77
+//   Dsg OFF  (0x0002): DD 5A E1 02 00 02 FF 1B 77
+//   Both OFF (0x0003): DD 5A E1 02 00 03 FF 1A 77
+
+// ── Frame header / trailer ────────────────────────────────────────────────────
+
+TEST(WriteCommandTest, HeaderAndTrailer) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+
+  EXPECT_EQ(f[0], 0xDD);  // SOF
+  EXPECT_EQ(f[1], 0x5A);  // CMD_WRITE
+  EXPECT_EQ(f[3], 0x02);  // data length
+  EXPECT_EQ(f[8], 0x77);  // EOF
+}
+
+// ── CRC ───────────────────────────────────────────────────────────────────────
+
+TEST(WriteCommandTest, CrcBothEnabled) {
+  TestableJbdBmsBle bms;
+  // sum(E1, 02, 00, 00) = 0xE3 → CRC = 0x10000 - 0xE3 = 0xFF1D
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  EXPECT_EQ(f[6], 0xFF);
+  EXPECT_EQ(f[7], 0x1D);
+}
+
+TEST(WriteCommandTest, CrcMatchesTwosComplement) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+
+  uint16_t sum = 0;
+  for (int i = 2; i <= 5; i++)
+    sum += f[i];
+  uint16_t expected = static_cast<uint16_t>(0x10000u - sum);
+
+  EXPECT_EQ(f[6], expected >> 8);
+  EXPECT_EQ(f[7], expected & 0xFF);
+}
+
+// ── Full frame comparisons against physical captures ─────────────────────────
+
+TEST(WriteCommandTest, FrameBothEnabled) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x00, 0xFF, 0x1D, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(WriteCommandTest, FrameChargingDisabled) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x01, 0xFF, 0x1C, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(WriteCommandTest, FrameDischargingDisabled) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0002);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x02, 0xFF, 0x1B, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(WriteCommandTest, FrameBothDisabled) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0x5A, 0xE1, 0x0003);
+
+  // clang-format off
+  const std::array<uint8_t, 9> expected = {
+      0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x03, 0xFF, 0x1A, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+// ── change_mosfet_status state transitions ───────────────────────────────────
+
+TEST(MosfetSwitchTest, ChargingOffFromBothEnabled) {
+  TestableJbdBmsBle bms;
+  bms.set_mosfet_status(0x03);
+  bms.change_mosfet_status(0xE1, 0, false);
+
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0001);
+}
+
+TEST(MosfetSwitchTest, DischargingOffFromBothEnabled) {
+  TestableJbdBmsBle bms;
+  bms.set_mosfet_status(0x03);
+  bms.change_mosfet_status(0xE1, 1, false);
+
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0002);
+}
+
+TEST(MosfetSwitchTest, BothOffFromBothEnabled) {
+  TestableJbdBmsBle bms;
+  bms.set_mosfet_status(0x03);
+  bms.change_mosfet_status(0xE1, 0, false);  // charging off → mosfet_status_=0x02
+  bms.change_mosfet_status(0xE1, 1, false);  // discharging off → mosfet_status_=0x00
+
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0003);
+}
+
+TEST(MosfetSwitchTest, ChargingOnFromBothDisabled) {
+  TestableJbdBmsBle bms;
+  bms.set_mosfet_status(0x00);
+  bms.change_mosfet_status(0xE1, 0, true);
+
+  EXPECT_EQ(bms.last_write_address, 0xE1);
+  EXPECT_EQ(bms.last_write_value, 0x0002);
+}
+
+TEST(MosfetSwitchTest, UnknownStatusReturnsError) {
+  TestableJbdBmsBle bms;
+  bool result = bms.change_mosfet_status(0xE1, 0, false);
+  EXPECT_FALSE(result);
+}
+
+}  // namespace esphome::jbd_bms_ble::testing


### PR DESCRIPTION
## Summary

- Extracts `build_write_frame_()` (protected const) from `write_register()` in `jbd_bms.cpp`, enabling the frame builder to be tested independently of UART I/O
- Makes `write_register()` virtual so `TestableJbdBms` can capture write calls without touching hardware
- Adds `write_command_test.cpp` with byte-exact frame comparisons against 4 physical PulseView captures of register 0xE1 (MOS control) and full `change_mosfet_status()` state-transition coverage

## Test plan

- [ ] CI C++ unit tests pass (`script/cpp_unit_test.py jbd_bms jbd_bms_ble`)
- [ ] `FrameBothEnabled` / `FrameChargingDisabled` / `FrameDischargingDisabled` / `FrameBothDisabled` match physical captures byte-for-byte
- [ ] `MosfetSwitchTest` transitions verify inverted-bit encoding (XOR 0x03) and unknown-status guard