### PR TITLE
Add automatic_balancing and clear_alarm button entities

### DIFF
--- a/components/jbd_bms/button/__init__.py
+++ b/components/jbd_bms/button/__init__.py
@@ -11,11 +11,18 @@ CODEOWNERS = ["@syssi"]
 CONF_RETRIEVE_HARDWARE_VERSION = "retrieve_hardware_version"
 CONF_RETRIEVE_ERROR_COUNTS = "retrieve_error_counts"
 CONF_FORCE_SOC_RESET = "force_soc_reset"
+CONF_AUTOMATIC_BALANCING = "automatic_balancing"
+CONF_CLEAR_ALARM = "clear_alarm"
+
+JBD_CMD_READ = 0xA5
+JBD_CMD_WRITE = 0x5A
 
 BUTTONS = {
-    CONF_RETRIEVE_HARDWARE_VERSION: 0x05,
-    CONF_RETRIEVE_ERROR_COUNTS: 0xAA,
-    CONF_FORCE_SOC_RESET: 0x0A,
+    CONF_RETRIEVE_HARDWARE_VERSION: (JBD_CMD_READ, 0x05, []),
+    CONF_RETRIEVE_ERROR_COUNTS: (JBD_CMD_READ, 0xAA, []),
+    CONF_FORCE_SOC_RESET: (JBD_CMD_WRITE, 0x0A, [0x01, 0x00]),
+    CONF_AUTOMATIC_BALANCING: (JBD_CMD_WRITE, 0x0A, [0x07, 0x00]),
+    CONF_CLEAR_ALARM: (JBD_CMD_WRITE, 0x0A, [0x04, 0x00]),
 }
 
 JbdButton = jbd_bms_ns.class_("JbdButton", button.Button, cg.Component)
@@ -34,16 +41,27 @@ CONFIG_SCHEMA = JBD_BMS_COMPONENT_SCHEMA.extend(
             JbdButton,
             icon="mdi:battery-charging-100",
         ),
+        cv.Optional(CONF_AUTOMATIC_BALANCING): button.button_schema(
+            JbdButton,
+            icon="mdi:scale-balance",
+        ),
+        cv.Optional(CONF_CLEAR_ALARM): button.button_schema(
+            JbdButton,
+            icon="mdi:alarm-off",
+        ),
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_JBD_BMS_ID])
-    for key, address in BUTTONS.items():
+    for key, (action, register, data) in BUTTONS.items():
         if key in config:
             conf = config[key]
             var = await button.new_button(conf)
             await cg.register_component(var, conf)
             cg.add(var.set_parent(hub))
-            cg.add(var.set_holding_register(address))
+            cg.add(var.set_command(action))
+            cg.add(var.set_address(register))
+            if data:
+                cg.add(var.set_payload(data[0], data[1]))

--- a/components/jbd_bms/button/jbd_button.cpp
+++ b/components/jbd_bms/button/jbd_button.cpp
@@ -6,17 +6,9 @@ namespace esphome::jbd_bms {
 
 static const char *const TAG = "jbd_bms.button";
 
-static const uint8_t JBD_CMD_READ = 0xA5;
-static const uint8_t JBD_CMD_FORCE_SOC_RESET = 0x0A;
-
 void JbdButton::dump_config() { LOG_BUTTON("", "JbdBms Button", this); }
 void JbdButton::press_action() {
-  if (this->holding_register_ == JBD_CMD_FORCE_SOC_RESET) {
-    this->parent_->write_register(this->holding_register_, 0x0100);
-    return;
-  }
-
-  this->parent_->send_command(JBD_CMD_READ, this->holding_register_);
+  this->parent_->send_command(this->command_, this->address_, this->payload_, this->length_);
 }
 
 }  // namespace esphome::jbd_bms

--- a/components/jbd_bms/button/jbd_button.h
+++ b/components/jbd_bms/button/jbd_button.h
@@ -10,7 +10,13 @@ class JbdBms;
 class JbdButton : public button::Button, public Component {
  public:
   void set_parent(JbdBms *parent) { this->parent_ = parent; };
-  void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void set_command(uint8_t command) { this->command_ = command; };
+  void set_address(uint8_t address) { this->address_ = address; };
+  void set_payload(uint8_t high, uint8_t low) {
+    this->payload_[0] = high;
+    this->payload_[1] = low;
+    this->length_ = 2;
+  };
   void dump_config() override;
   void loop() override {}
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -18,7 +24,10 @@ class JbdButton : public button::Button, public Component {
  protected:
   void press_action() override;
   JbdBms *parent_;
-  uint8_t holding_register_;
+  uint8_t command_{0};
+  uint8_t address_{0};
+  uint8_t payload_[2]{};
+  uint8_t length_{0};
 };
 
 }  // namespace esphome::jbd_bms

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -65,7 +65,7 @@ void JbdBms::setup() {
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->setup();
   }
-  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
+  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO, nullptr, 0);
 }
 
 void JbdBms::loop() {
@@ -93,7 +93,7 @@ void JbdBms::loop() {
 
 void JbdBms::update() {
   this->track_online_status_();
-  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
+  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO, nullptr, 0);
 }
 
 bool JbdBms::parse_jbd_bms_byte_(uint8_t byte) {
@@ -176,7 +176,7 @@ void JbdBms::on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t>
   switch (function) {
     case JBD_CMD_HWINFO:
       this->on_hardware_info_data_(data);
-      this->send_command(JBD_CMD_READ, JBD_CMD_CELLINFO);
+      this->send_command(JBD_CMD_READ, JBD_CMD_CELLINFO, nullptr, 0);
       break;
     case JBD_CMD_CELLINFO:
       this->on_cell_info_data_(data);

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -65,7 +65,7 @@ void JbdBms::setup() {
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->setup();
   }
-  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
+  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO, nullptr, 0);
 }
 
 void JbdBms::loop() {
@@ -93,7 +93,7 @@ void JbdBms::loop() {
 
 void JbdBms::update() {
   this->track_online_status_();
-  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
+  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO, nullptr, 0);
 }
 
 bool JbdBms::parse_jbd_bms_byte_(uint8_t byte) {
@@ -176,7 +176,7 @@ void JbdBms::on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t>
   switch (function) {
     case JBD_CMD_HWINFO:
       this->on_hardware_info_data_(data);
-      this->send_command(JBD_CMD_READ, JBD_CMD_CELLINFO);
+      this->send_command(JBD_CMD_READ, JBD_CMD_CELLINFO, nullptr, 0);
       break;
     case JBD_CMD_CELLINFO:
       this->on_cell_info_data_(data);
@@ -596,53 +596,35 @@ bool JbdBms::change_mosfet_status(uint8_t address, uint8_t bitmask, bool state) 
   return this->write_register(address, value);
 }
 
-std::array<uint8_t, 9> JbdBms::build_frame_(uint8_t command, uint8_t address, uint16_t value) const {
-  std::array<uint8_t, 9> frame{};
+std::vector<uint8_t> JbdBms::build_frame_(uint8_t command, uint8_t address, const uint8_t *data,
+                                          uint8_t data_len) const {
+  std::vector<uint8_t> frame(data_len + 7);
   frame[0] = JBD_PKT_START;
   frame[1] = command;
   frame[2] = address;
-  frame[3] = 0x02;
-  frame[4] = value >> 8;
-  frame[5] = value >> 0;
-  auto crc = chksum_(frame.data() + 2, 4);
-  frame[6] = crc >> 8;
-  frame[7] = crc >> 0;
-  frame[8] = JBD_PKT_END;
+  frame[3] = data_len;
+  for (uint8_t i = 0; i < data_len; i++)
+    frame[4 + i] = data[i];
+  auto crc = chksum_(frame.data() + 2, data_len + 2);
+  frame[4 + data_len] = crc >> 8;
+  frame[5 + data_len] = crc >> 0;
+  frame[6 + data_len] = JBD_PKT_END;
   return frame;
 }
 
 bool JbdBms::write_register(uint8_t address, uint16_t value) {
-  if (this->flow_control_pin_ != nullptr)
-    this->flow_control_pin_->digital_write(true);
-
-  auto frame = build_frame_(JBD_CMD_WRITE, address, value);
-  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
-  this->write_array(frame.data(), frame.size());
-  this->flush();
-
-  if (this->flow_control_pin_ != nullptr)
-    this->flow_control_pin_->digital_write(false);
-
+  uint8_t data[2] = {(uint8_t) (value >> 8), (uint8_t) (value)};
+  this->send_command(JBD_CMD_WRITE, address, data, 2);
   return true;
 }
 
-void JbdBms::send_command(uint8_t action, uint8_t function) {
+void JbdBms::send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) {
   if (this->flow_control_pin_ != nullptr)
     this->flow_control_pin_->digital_write(true);
 
-  uint8_t frame[7];
-  uint8_t data_len = 0;
-
-  frame[0] = JBD_PKT_START;
-  frame[1] = action;
-  frame[2] = function;
-  frame[3] = data_len;
-  auto crc = chksum_(frame + 2, data_len + 2);
-  frame[4] = crc >> 8;
-  frame[5] = crc >> 0;
-  frame[6] = JBD_PKT_END;
-
-  this->write_array(frame, 7);
+  auto frame = build_frame_(command, address, data, data_len);
+  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
+  this->write_array(frame.data(), frame.size());
   this->flush();
 
   if (this->flow_control_pin_ != nullptr)

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -65,7 +65,7 @@ void JbdBms::setup() {
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->setup();
   }
-  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO, nullptr, 0);
+  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
 }
 
 void JbdBms::loop() {
@@ -93,7 +93,7 @@ void JbdBms::loop() {
 
 void JbdBms::update() {
   this->track_online_status_();
-  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO, nullptr, 0);
+  this->send_command(JBD_CMD_READ, JBD_CMD_HWINFO);
 }
 
 bool JbdBms::parse_jbd_bms_byte_(uint8_t byte) {
@@ -176,7 +176,7 @@ void JbdBms::on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t>
   switch (function) {
     case JBD_CMD_HWINFO:
       this->on_hardware_info_data_(data);
-      this->send_command(JBD_CMD_READ, JBD_CMD_CELLINFO, nullptr, 0);
+      this->send_command(JBD_CMD_READ, JBD_CMD_CELLINFO);
       break;
     case JBD_CMD_CELLINFO:
       this->on_cell_info_data_(data);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -202,7 +202,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   }
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
-  virtual void send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len);
+  void send_command(uint8_t command, uint8_t address, const uint8_t *data = nullptr, uint8_t data_len = 0);
   virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
   void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <array>
+#include <vector>
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/select/select.h"
@@ -202,7 +202,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   }
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
-  virtual void send_command(uint8_t action, uint8_t function);
+  virtual void send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len);
   virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
   void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
@@ -307,7 +307,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void track_online_status_();
   std::string bitmask_to_string_(const char *const messages[], const uint8_t &messages_size, const uint16_t &mask);
 
-  std::array<uint8_t, 9> build_frame_(uint8_t command, uint8_t address, uint16_t value) const;
+  std::vector<uint8_t> build_frame_(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) const;
 
   uint16_t chksum_(const uint8_t data[], const uint16_t len) const {
     uint16_t checksum = 0x00;

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -202,7 +202,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   }
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
-  void send_command(uint8_t command, uint8_t address, const uint8_t *data = nullptr, uint8_t data_len = 0);
+  virtual void send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len);
   virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
   void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);

--- a/components/jbd_bms/select/jbd_select.cpp
+++ b/components/jbd_bms/select/jbd_select.cpp
@@ -21,7 +21,7 @@ void JbdSelect::control(const std::string &value) {
   if (idx.has_value()) {
     uint8_t mapping = this->mappings_.at(idx.value());
     ESP_LOGV(TAG, "Reading register to %u", mapping);
-    this->parent_->send_command(JBD_CMD_READ, mapping);
+    this->parent_->send_command(JBD_CMD_READ, mapping, nullptr, 0);
     return;
   }
 

--- a/components/jbd_bms/select/jbd_select.cpp
+++ b/components/jbd_bms/select/jbd_select.cpp
@@ -21,7 +21,7 @@ void JbdSelect::control(const std::string &value) {
   if (idx.has_value()) {
     uint8_t mapping = this->mappings_.at(idx.value());
     ESP_LOGV(TAG, "Reading register to %u", mapping);
-    this->parent_->send_command(JBD_CMD_READ, mapping, nullptr, 0);
+    this->parent_->send_command(JBD_CMD_READ, mapping);
     return;
   }
 

--- a/components/jbd_bms/switch/__init__.py
+++ b/components/jbd_bms/switch/__init__.py
@@ -53,5 +53,5 @@ async def to_code(config):
             await cg.register_component(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
-            cg.add(var.set_holding_register(address[0]))
+            cg.add(var.set_address(address[0]))
             cg.add(var.set_bitmask(address[1]))

--- a/components/jbd_bms/switch/jbd_switch.cpp
+++ b/components/jbd_bms/switch/jbd_switch.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "jbd_bms.switch";
 
 void JbdSwitch::dump_config() { LOG_SWITCH("", "JbdBms Switch", this); }
 void JbdSwitch::write_state(bool state) {
-  if (this->parent_->change_mosfet_status(this->holding_register_, this->bitmask_, state)) {
+  if (this->parent_->change_mosfet_status(this->address_, this->bitmask_, state)) {
     this->publish_state(state);
   }
 

--- a/components/jbd_bms/switch/jbd_switch.h
+++ b/components/jbd_bms/switch/jbd_switch.h
@@ -10,7 +10,7 @@ class JbdBms;
 class JbdSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(JbdBms *parent) { this->parent_ = parent; };
-  void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void set_address(uint8_t address) { this->address_ = address; };
   void set_bitmask(uint8_t bitmask) { this->bitmask_ = bitmask; };
   void dump_config() override;
   void loop() override {}
@@ -19,7 +19,7 @@ class JbdSwitch : public switch_::Switch, public Component {
  protected:
   void write_state(bool state) override;
   JbdBms *parent_;
-  uint8_t holding_register_;
+  uint8_t address_;
   uint8_t bitmask_;
 };
 

--- a/components/jbd_bms_ble/button/__init__.py
+++ b/components/jbd_bms_ble/button/__init__.py
@@ -11,11 +11,18 @@ CODEOWNERS = ["@syssi"]
 CONF_RETRIEVE_HARDWARE_VERSION = "retrieve_hardware_version"
 CONF_RETRIEVE_ERROR_COUNTS = "retrieve_error_counts"
 CONF_FORCE_SOC_RESET = "force_soc_reset"
+CONF_AUTOMATIC_BALANCING = "automatic_balancing"
+CONF_CLEAR_ALARM = "clear_alarm"
+
+JBD_CMD_READ = 0xA5
+JBD_CMD_WRITE = 0x5A
 
 BUTTONS = {
-    CONF_RETRIEVE_HARDWARE_VERSION: 0x05,
-    CONF_RETRIEVE_ERROR_COUNTS: 0xAA,
-    CONF_FORCE_SOC_RESET: 0x0A,
+    CONF_RETRIEVE_HARDWARE_VERSION: (JBD_CMD_READ, 0x05, []),
+    CONF_RETRIEVE_ERROR_COUNTS: (JBD_CMD_READ, 0xAA, []),
+    CONF_FORCE_SOC_RESET: (JBD_CMD_WRITE, 0x0A, [0x01, 0x00]),
+    CONF_AUTOMATIC_BALANCING: (JBD_CMD_WRITE, 0x0A, [0x07, 0x00]),
+    CONF_CLEAR_ALARM: (JBD_CMD_WRITE, 0x0A, [0x04, 0x00]),
 }
 
 JbdButton = jbd_bms_ble_ns.class_("JbdButton", button.Button, cg.Component)
@@ -34,16 +41,27 @@ CONFIG_SCHEMA = JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
             JbdButton,
             icon="mdi:battery-charging-100",
         ),
+        cv.Optional(CONF_AUTOMATIC_BALANCING): button.button_schema(
+            JbdButton,
+            icon="mdi:scale-balance",
+        ),
+        cv.Optional(CONF_CLEAR_ALARM): button.button_schema(
+            JbdButton,
+            icon="mdi:alarm-off",
+        ),
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_JBD_BMS_BLE_ID])
-    for key, address in BUTTONS.items():
+    for key, (action, register, data) in BUTTONS.items():
         if key in config:
             conf = config[key]
             var = await button.new_button(conf)
             await cg.register_component(var, conf)
             cg.add(var.set_parent(hub))
-            cg.add(var.set_holding_register(address))
+            cg.add(var.set_command(action))
+            cg.add(var.set_address(register))
+            if data:
+                cg.add(var.set_payload(data[0], data[1]))

--- a/components/jbd_bms_ble/button/jbd_button.cpp
+++ b/components/jbd_bms_ble/button/jbd_button.cpp
@@ -6,17 +6,9 @@ namespace esphome::jbd_bms_ble {
 
 static const char *const TAG = "jbd_bms_ble.button";
 
-static const uint8_t JBD_CMD_READ = 0xA5;
-static const uint8_t JBD_CMD_FORCE_SOC_RESET = 0x0A;
-
 void JbdButton::dump_config() { LOG_BUTTON("", "JbdBmsBle Button", this); }
 void JbdButton::press_action() {
-  if (this->holding_register_ == JBD_CMD_FORCE_SOC_RESET) {
-    this->parent_->write_register(this->holding_register_, 0x0100);
-    return;
-  }
-
-  this->parent_->send_command(JBD_CMD_READ, this->holding_register_);
+  this->parent_->send_command(this->command_, this->address_, this->payload_, this->length_);
 }
 
 }  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/button/jbd_button.h
+++ b/components/jbd_bms_ble/button/jbd_button.h
@@ -10,7 +10,13 @@ class JbdBmsBle;
 class JbdButton : public button::Button, public Component {
  public:
   void set_parent(JbdBmsBle *parent) { this->parent_ = parent; };
-  void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void set_command(uint8_t command) { this->command_ = command; };
+  void set_address(uint8_t address) { this->address_ = address; };
+  void set_payload(uint8_t high, uint8_t low) {
+    this->payload_[0] = high;
+    this->payload_[1] = low;
+    this->length_ = 2;
+  };
   void dump_config() override;
   void loop() override {}
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -18,7 +24,10 @@ class JbdButton : public button::Button, public Component {
  protected:
   void press_action() override;
   JbdBmsBle *parent_;
-  uint8_t holding_register_;
+  uint8_t command_{0};
+  uint8_t address_{0};
+  uint8_t payload_[2]{};
+  uint8_t length_{0};
 };
 
 }  // namespace esphome::jbd_bms_ble

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -1,5 +1,4 @@
 #include "jbd_bms_ble.h"
-#include <array>
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/version.h"
@@ -838,18 +837,19 @@ void JbdBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::
   text_sensor->publish_state(state);
 }
 
-std::array<uint8_t, 9> JbdBmsBle::build_frame_(uint8_t command, uint8_t address, uint16_t value) const {
-  std::array<uint8_t, 9> frame{};
+std::vector<uint8_t> JbdBmsBle::build_frame_(uint8_t command, uint8_t address, const uint8_t *data,
+                                             uint8_t data_len) const {
+  std::vector<uint8_t> frame(data_len + 7);
   frame[0] = JBD_PKT_START;
   frame[1] = command;
   frame[2] = address;
-  frame[3] = 0x02;
-  frame[4] = value >> 8;
-  frame[5] = value >> 0;
-  auto crc = chksum_(frame.data() + 2, 4);
-  frame[6] = crc >> 8;
-  frame[7] = crc >> 0;
-  frame[8] = JBD_PKT_END;
+  frame[3] = data_len;
+  for (uint8_t i = 0; i < data_len; i++)
+    frame[4 + i] = data[i];
+  auto crc = chksum_(frame.data() + 2, data_len + 2);
+  frame[4 + data_len] = crc >> 8;
+  frame[5 + data_len] = crc >> 0;
+  frame[6 + data_len] = JBD_PKT_END;
   return frame;
 }
 
@@ -870,8 +870,8 @@ bool JbdBmsBle::change_mosfet_status(uint8_t address, uint8_t bitmask, bool stat
 }
 
 #ifdef USE_ESP32
-bool JbdBmsBle::write_register(uint8_t address, uint16_t value) {
-  auto frame = build_frame_(JBD_CMD_WRITE, address, value);
+bool JbdBmsBle::send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) {
+  auto frame = build_frame_(command, address, data, data_len);
   ESP_LOGV(TAG, "Send command (handle 0x%02X): %s", this->char_command_handle_,
            format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
   auto status =
@@ -884,36 +884,14 @@ bool JbdBmsBle::write_register(uint8_t address, uint16_t value) {
 
   return (status == 0);
 }
-
-bool JbdBmsBle::send_command(uint8_t action, uint8_t function) {
-  uint8_t frame[7];
-  uint8_t data_len = 0;
-
-  frame[0] = JBD_PKT_START;
-  frame[1] = action;
-  frame[2] = function;
-  frame[3] = data_len;
-  auto crc = chksum_(frame + 2, data_len + 2);
-  frame[4] = crc >> 8;
-  frame[5] = crc >> 0;
-  frame[6] = JBD_PKT_END;
-
-  ESP_LOGV(TAG, "Send command (handle 0x%02X): %s", this->char_command_handle_,
-           format_hex_pretty(frame, sizeof(frame)).c_str());  // NOLINT
-  auto status =
-      esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_command_handle_,
-                               sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-
-  if (status) {
-    ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", ADDR_STR(this->parent_->address_str()), status);
-  }
-
-  return (status == 0);
-}
 #else
-bool JbdBmsBle::write_register(uint8_t address, uint16_t value) { return false; }
-bool JbdBmsBle::send_command(uint8_t action, uint8_t function) { return false; }
+bool JbdBmsBle::send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) { return false; }
 #endif  // USE_ESP32
+
+bool JbdBmsBle::write_register(uint8_t address, uint16_t value) {
+  uint8_t data[2] = {(uint8_t) (value >> 8), (uint8_t) (value)};
+  return this->send_command(JBD_CMD_WRITE, address, data, 2);
+}
 
 std::string JbdBmsBle::bitmask_to_string_(const char *const messages[], const uint8_t &messages_size,
                                           const uint16_t &mask) {

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <array>
+#include <vector>
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/select/select.h"
@@ -218,7 +218,7 @@ class JbdBmsBle :
   }
   void set_authentication_timeout(uint32_t timeout_ms) { auth_timeout_ms_ = timeout_ms; }
 
-  bool send_command(uint8_t action, uint8_t function);
+  bool send_command(uint8_t command, uint8_t address, const uint8_t *data = nullptr, uint8_t data_len = 0);
   virtual bool write_register(uint8_t address, uint16_t value);
   bool change_mosfet_status(uint8_t address, uint8_t bitmask, bool state);
   void on_jbd_bms_data(const uint8_t &function, const std::vector<uint8_t> &data);
@@ -322,7 +322,7 @@ class JbdBmsBle :
   void track_online_status_();
   std::string bitmask_to_string_(const char *const messages[], const uint8_t &messages_size, const uint16_t &mask);
 
-  std::array<uint8_t, 9> build_frame_(uint8_t command, uint8_t address, uint16_t value) const;
+  std::vector<uint8_t> build_frame_(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) const;
 
   uint16_t chksum_(const uint8_t data[], const uint16_t len) const {
     uint16_t checksum = 0x00;

--- a/components/jbd_bms_ble/switch/__init__.py
+++ b/components/jbd_bms_ble/switch/__init__.py
@@ -52,5 +52,5 @@ async def to_code(config):
             await cg.register_component(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
-            cg.add(var.set_holding_register(address[0]))
+            cg.add(var.set_address(address[0]))
             cg.add(var.set_bitmask(address[1]))

--- a/components/jbd_bms_ble/switch/jbd_switch.cpp
+++ b/components/jbd_bms_ble/switch/jbd_switch.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "jbd_bms_ble.switch";
 
 void JbdSwitch::dump_config() { LOG_SWITCH("", "JbdBmsBle Switch", this); }
 void JbdSwitch::write_state(bool state) {
-  if (this->parent_->change_mosfet_status(this->holding_register_, this->bitmask_, state)) {
+  if (this->parent_->change_mosfet_status(this->address_, this->bitmask_, state)) {
     this->publish_state(state);
   }
 

--- a/components/jbd_bms_ble/switch/jbd_switch.h
+++ b/components/jbd_bms_ble/switch/jbd_switch.h
@@ -10,7 +10,7 @@ class JbdBmsBle;
 class JbdSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(JbdBmsBle *parent) { this->parent_ = parent; };
-  void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void set_address(uint8_t address) { this->address_ = address; };
   void set_bitmask(uint8_t bitmask) { this->bitmask_ = bitmask; };
   void dump_config() override;
   void loop() override {}
@@ -19,7 +19,7 @@ class JbdSwitch : public switch_::Switch, public Component {
  protected:
   void write_state(bool state) override;
   JbdBmsBle *parent_;
-  uint8_t holding_register_;
+  uint8_t address_;
   uint8_t bitmask_;
 };
 

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -84,6 +84,12 @@ button:
     force_soc_reset:
       name: "force soc reset"
       device_id: device0
+    automatic_balancing:
+      name: "automatic balancing"
+      device_id: device0
+    clear_alarm:
+      name: "clear alarm"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
@@ -95,6 +101,12 @@ button:
       device_id: device1
     force_soc_reset:
       name: "force soc reset"
+      device_id: device1
+    automatic_balancing:
+      name: "automatic balancing"
+      device_id: device1
+    clear_alarm:
+      name: "clear alarm"
       device_id: device1
 
 binary_sensor:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -92,6 +92,10 @@ button:
       name: "retrieve error counts"
     force_soc_reset:
       name: "force soc reset"
+    automatic_balancing:
+      name: "automatic balancing"
+    clear_alarm:
+      name: "clear alarm"
 
 binary_sensor:
   - platform: jbd_bms_ble

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -86,6 +86,10 @@ button:
       name: "retrieve error counts"
     force_soc_reset:
       name: "force soc reset"
+    automatic_balancing:
+      name: "automatic balancing"
+    clear_alarm:
+      name: "clear alarm"
 
 binary_sensor:
   - platform: jbd_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -84,6 +84,10 @@ button:
       name: "retrieve error counts"
     force_soc_reset:
       name: "force soc reset"
+    automatic_balancing:
+      name: "automatic balancing"
+    clear_alarm:
+      name: "clear alarm"
 
 binary_sensor:
   - platform: jbd_bms

--- a/tests/components/jbd_bms/common.h
+++ b/tests/components/jbd_bms/common.h
@@ -10,6 +10,7 @@ namespace esphome::jbd_bms::testing {
 class TestableJbdBms : public JbdBms {
  public:
   void update() override {}
+  void send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) override {}
 
   void set_mosfet_status(uint8_t status) { this->mosfet_status_ = status; }
   bool write_register(uint8_t address, uint16_t value) override {

--- a/tests/components/jbd_bms/common.h
+++ b/tests/components/jbd_bms/common.h
@@ -10,7 +10,7 @@ namespace esphome::jbd_bms::testing {
 class TestableJbdBms : public JbdBms {
  public:
   void update() override {}
-  void send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) override {}
+
   void set_mosfet_status(uint8_t status) { this->mosfet_status_ = status; }
   bool write_register(uint8_t address, uint16_t value) override {
     last_write_address = address;

--- a/tests/components/jbd_bms/common.h
+++ b/tests/components/jbd_bms/common.h
@@ -10,7 +10,7 @@ namespace esphome::jbd_bms::testing {
 class TestableJbdBms : public JbdBms {
  public:
   void update() override {}
-  void send_command(uint8_t action, uint8_t function) override {}
+  void send_command(uint8_t command, uint8_t address, const uint8_t *data, uint8_t data_len) override {}
   void set_mosfet_status(uint8_t status) { this->mosfet_status_ = status; }
   bool write_register(uint8_t address, uint16_t value) override {
     last_write_address = address;

--- a/tests/components/jbd_bms/write_command_test.cpp
+++ b/tests/components/jbd_bms/write_command_test.cpp
@@ -1,21 +1,20 @@
 #include <gtest/gtest.h>
-#include <array>
+#include <vector>
 #include "common.h"
 
 namespace esphome::jbd_bms::testing {
 
-// JBD write frame layout (9 bytes):
-//   [0]    SOF         0xDD
-//   [1]    CMD_WRITE   0x5A
-//   [2]    address
-//   [3]    data_len    0x02
-//   [4]    value high
-//   [5]    value low
-//   [6]    CRC high
-//   [7]    CRC low
-//   [8]    EOF         0x77
+// JBD write frame layout (variable length):
+//   [0]        SOF         0xDD
+//   [1]        CMD         0x5A (write) / 0xA5 (read)
+//   [2]        address
+//   [3]        data_len    n
+//   [4..4+n-1] data
+//   [4+n]      CRC high
+//   [5+n]      CRC low
+//   [6+n]      EOF         0x77
 //
-// CRC = 0x10000 - sum(frame[2..5])   (two's complement, 16-bit)
+// CRC = 0x10000 - sum(frame[2..3+n])   (two's complement, 16-bit)
 //
 // Physical PulseView captures (register 0xE1 = MOS control):
 //   Both ON  (0x0000): DD 5A E1 02 00 00 FF 1D 77   (initial state: charging+discharging enabled)
@@ -27,7 +26,8 @@ namespace esphome::jbd_bms::testing {
 
 TEST(WriteCommandTest, HeaderAndTrailer) {
   TestableJbdBms bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  const uint8_t data[2] = {0x00, 0x00};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   EXPECT_EQ(f[0], 0xDD);  // SOF
   EXPECT_EQ(f[1], 0x5A);  // CMD_WRITE
@@ -40,14 +40,16 @@ TEST(WriteCommandTest, HeaderAndTrailer) {
 TEST(WriteCommandTest, CrcBothEnabled) {
   TestableJbdBms bms;
   // sum(E1, 02, 00, 00) = 0xE3 → CRC = 0x10000 - 0xE3 = 0xFF1D
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  const uint8_t data[2] = {0x00, 0x00};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
   EXPECT_EQ(f[6], 0xFF);
   EXPECT_EQ(f[7], 0x1D);
 }
 
 TEST(WriteCommandTest, CrcMatchesTwosComplement) {
   TestableJbdBms bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+  const uint8_t data[2] = {0x00, 0x01};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   uint16_t sum = 0;
   for (int i = 2; i <= 5; i++)
@@ -62,10 +64,11 @@ TEST(WriteCommandTest, CrcMatchesTwosComplement) {
 
 TEST(WriteCommandTest, FrameBothEnabled) {
   TestableJbdBms bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  const uint8_t data[2] = {0x00, 0x00};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x00, 0xFF, 0x1D, 0x77,
   };
   // clang-format on
@@ -74,10 +77,11 @@ TEST(WriteCommandTest, FrameBothEnabled) {
 
 TEST(WriteCommandTest, FrameChargingDisabled) {
   TestableJbdBms bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+  const uint8_t data[2] = {0x00, 0x01};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x01, 0xFF, 0x1C, 0x77,
   };
   // clang-format on
@@ -86,10 +90,11 @@ TEST(WriteCommandTest, FrameChargingDisabled) {
 
 TEST(WriteCommandTest, FrameDischargingDisabled) {
   TestableJbdBms bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0002);
+  const uint8_t data[2] = {0x00, 0x02};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x02, 0xFF, 0x1B, 0x77,
   };
   // clang-format on
@@ -98,10 +103,11 @@ TEST(WriteCommandTest, FrameDischargingDisabled) {
 
 TEST(WriteCommandTest, FrameBothDisabled) {
   TestableJbdBms bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0003);
+  const uint8_t data[2] = {0x00, 0x03};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x03, 0xFF, 0x1A, 0x77,
   };
   // clang-format on
@@ -165,6 +171,108 @@ TEST(MosfetSwitchTest, UnknownStatusReturnsError) {
   // mosfet_status_ defaults to 255 = unknown
   bool result = bms.change_mosfet_status(0xE1, 0, false);
   EXPECT_FALSE(result);
+}
+
+// ── Button command frames ─────────────────────────────────────────────────────
+//
+// Register 0x0A controls BMS operations via distinct bit patterns:
+//   automatic_balancing  0x0700: DD 5A 0A 02 07 00 FF ED 77
+//   clear_alarm          0x0400: DD 5A 0A 02 04 00 FF F0 77
+//   force_soc_reset      0x0100: DD 5A 0A 02 01 00 FF F3 77
+
+TEST(ButtonCommandTest, AutomaticBalancingFrame) {
+  TestableJbdBms bms;
+  const uint8_t data[2] = {0x07, 0x00};
+  auto f = bms.build_frame_(0x5A, 0x0A, data, 2);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0x5A, 0x0A, 0x02, 0x07, 0x00, 0xFF, 0xED, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ButtonCommandTest, ClearAlarmFrame) {
+  TestableJbdBms bms;
+  const uint8_t data[2] = {0x04, 0x00};
+  auto f = bms.build_frame_(0x5A, 0x0A, data, 2);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0x5A, 0x0A, 0x02, 0x04, 0x00, 0xFF, 0xF0, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ButtonCommandTest, ForceSocResetFrame) {
+  TestableJbdBms bms;
+  const uint8_t data[2] = {0x01, 0x00};
+  auto f = bms.build_frame_(0x5A, 0x0A, data, 2);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0x5A, 0x0A, 0x02, 0x01, 0x00, 0xFF, 0xF3, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+// ── Read command frames ───────────────────────────────────────────────────────
+//
+// Read frames carry no payload (data_len=0); CRC covers only [address, 0x00].
+//   hardware_info              reg 0x03: DD A5 03 00 FF FD 77  (confirmed: btsnoop_hci_jbd-sp04s034-l4s-200a-b-u.log)
+//   cell_info                  reg 0x04: DD A5 04 00 FF FC 77  (confirmed: btsnoop_hci_jbd-sp04s034-l4s-200a-b-u.log)
+//   retrieve_hardware_version  reg 0x05: DD A5 05 00 FF FB 77  (confirmed: debug.txt)
+//   retrieve_error_counts      reg 0xAA: DD A5 AA 00 FF 56 77  (confirmed: btsnoop_hci_jbd-sp04s034-l4s-200a-b-u.log)
+
+TEST(ReadCommandTest, HardwareInfoFrame) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0xA5, 0x03, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0x03, 0x00, 0xFF, 0xFD, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ReadCommandTest, CellInfoFrame) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0xA5, 0x04, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0x04, 0x00, 0xFF, 0xFC, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ReadCommandTest, RetrieveHardwareVersionFrame) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0xA5, 0x05, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0x05, 0x00, 0xFF, 0xFB, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ReadCommandTest, RetrieveErrorCountsFrame) {
+  TestableJbdBms bms;
+  auto f = bms.build_frame_(0xA5, 0xAA, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0xAA, 0x00, 0xFF, 0x56, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
 }
 
 }  // namespace esphome::jbd_bms::testing

--- a/tests/components/jbd_bms_ble/write_command_test.cpp
+++ b/tests/components/jbd_bms_ble/write_command_test.cpp
@@ -1,21 +1,20 @@
 #include <gtest/gtest.h>
-#include <array>
+#include <vector>
 #include "common.h"
 
 namespace esphome::jbd_bms_ble::testing {
 
-// JBD write frame layout (9 bytes):
-//   [0]    SOF         0xDD
-//   [1]    CMD_WRITE   0x5A
-//   [2]    address
-//   [3]    data_len    0x02
-//   [4]    value high
-//   [5]    value low
-//   [6]    CRC high
-//   [7]    CRC low
-//   [8]    EOF         0x77
+// JBD write frame layout (variable length):
+//   [0]        SOF         0xDD
+//   [1]        CMD         0x5A (write) / 0xA5 (read)
+//   [2]        address
+//   [3]        data_len    n
+//   [4..4+n-1] data
+//   [4+n]      CRC high
+//   [5+n]      CRC low
+//   [6+n]      EOF         0x77
 //
-// CRC = 0x10000 - sum(frame[2..5])   (two's complement, 16-bit)
+// CRC = 0x10000 - sum(frame[2..3+n])   (two's complement, 16-bit)
 //
 // Physical PulseView captures (register 0xE1 = MOS control):
 //   Both ON  (0x0000): DD 5A E1 02 00 00 FF 1D 77
@@ -27,7 +26,8 @@ namespace esphome::jbd_bms_ble::testing {
 
 TEST(WriteCommandTest, HeaderAndTrailer) {
   TestableJbdBmsBle bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  const uint8_t data[2] = {0x00, 0x00};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   EXPECT_EQ(f[0], 0xDD);  // SOF
   EXPECT_EQ(f[1], 0x5A);  // CMD_WRITE
@@ -40,14 +40,16 @@ TEST(WriteCommandTest, HeaderAndTrailer) {
 TEST(WriteCommandTest, CrcBothEnabled) {
   TestableJbdBmsBle bms;
   // sum(E1, 02, 00, 00) = 0xE3 → CRC = 0x10000 - 0xE3 = 0xFF1D
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  const uint8_t data[2] = {0x00, 0x00};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
   EXPECT_EQ(f[6], 0xFF);
   EXPECT_EQ(f[7], 0x1D);
 }
 
 TEST(WriteCommandTest, CrcMatchesTwosComplement) {
   TestableJbdBmsBle bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+  const uint8_t data[2] = {0x00, 0x01};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   uint16_t sum = 0;
   for (int i = 2; i <= 5; i++)
@@ -62,10 +64,11 @@ TEST(WriteCommandTest, CrcMatchesTwosComplement) {
 
 TEST(WriteCommandTest, FrameBothEnabled) {
   TestableJbdBmsBle bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0000);
+  const uint8_t data[2] = {0x00, 0x00};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x00, 0xFF, 0x1D, 0x77,
   };
   // clang-format on
@@ -74,10 +77,11 @@ TEST(WriteCommandTest, FrameBothEnabled) {
 
 TEST(WriteCommandTest, FrameChargingDisabled) {
   TestableJbdBmsBle bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0001);
+  const uint8_t data[2] = {0x00, 0x01};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x01, 0xFF, 0x1C, 0x77,
   };
   // clang-format on
@@ -86,10 +90,11 @@ TEST(WriteCommandTest, FrameChargingDisabled) {
 
 TEST(WriteCommandTest, FrameDischargingDisabled) {
   TestableJbdBmsBle bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0002);
+  const uint8_t data[2] = {0x00, 0x02};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x02, 0xFF, 0x1B, 0x77,
   };
   // clang-format on
@@ -98,10 +103,11 @@ TEST(WriteCommandTest, FrameDischargingDisabled) {
 
 TEST(WriteCommandTest, FrameBothDisabled) {
   TestableJbdBmsBle bms;
-  auto f = bms.build_frame_(0x5A, 0xE1, 0x0003);
+  const uint8_t data[2] = {0x00, 0x03};
+  auto f = bms.build_frame_(0x5A, 0xE1, data, 2);
 
   // clang-format off
-  const std::array<uint8_t, 9> expected = {
+  const std::vector<uint8_t> expected = {
       0xDD, 0x5A, 0xE1, 0x02, 0x00, 0x03, 0xFF, 0x1A, 0x77,
   };
   // clang-format on
@@ -151,6 +157,108 @@ TEST(MosfetSwitchTest, UnknownStatusReturnsError) {
   TestableJbdBmsBle bms;
   bool result = bms.change_mosfet_status(0xE1, 0, false);
   EXPECT_FALSE(result);
+}
+
+// ── Button command frames ─────────────────────────────────────────────────────
+//
+// Register 0x0A controls BMS operations via distinct bit patterns:
+//   automatic_balancing  0x0700: DD 5A 0A 02 07 00 FF ED 77
+//   clear_alarm          0x0400: DD 5A 0A 02 04 00 FF F0 77
+//   force_soc_reset      0x0100: DD 5A 0A 02 01 00 FF F3 77
+
+TEST(ButtonCommandTest, AutomaticBalancingFrame) {
+  TestableJbdBmsBle bms;
+  const uint8_t data[2] = {0x07, 0x00};
+  auto f = bms.build_frame_(0x5A, 0x0A, data, 2);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0x5A, 0x0A, 0x02, 0x07, 0x00, 0xFF, 0xED, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ButtonCommandTest, ClearAlarmFrame) {
+  TestableJbdBmsBle bms;
+  const uint8_t data[2] = {0x04, 0x00};
+  auto f = bms.build_frame_(0x5A, 0x0A, data, 2);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0x5A, 0x0A, 0x02, 0x04, 0x00, 0xFF, 0xF0, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ButtonCommandTest, ForceSocResetFrame) {
+  TestableJbdBmsBle bms;
+  const uint8_t data[2] = {0x01, 0x00};
+  auto f = bms.build_frame_(0x5A, 0x0A, data, 2);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0x5A, 0x0A, 0x02, 0x01, 0x00, 0xFF, 0xF3, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+// ── Read command frames ───────────────────────────────────────────────────────
+//
+// Read frames carry no payload (data_len=0); CRC covers only [address, 0x00].
+//   hardware_info              reg 0x03: DD A5 03 00 FF FD 77  (confirmed: btsnoop_hci_jbd-sp04s034-l4s-200a-b-u.log)
+//   cell_info                  reg 0x04: DD A5 04 00 FF FC 77  (confirmed: btsnoop_hci_jbd-sp04s034-l4s-200a-b-u.log)
+//   retrieve_hardware_version  reg 0x05: DD A5 05 00 FF FB 77  (confirmed: debug.txt)
+//   retrieve_error_counts      reg 0xAA: DD A5 AA 00 FF 56 77  (confirmed: btsnoop_hci_jbd-sp04s034-l4s-200a-b-u.log)
+
+TEST(ReadCommandTest, HardwareInfoFrame) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0xA5, 0x03, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0x03, 0x00, 0xFF, 0xFD, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ReadCommandTest, CellInfoFrame) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0xA5, 0x04, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0x04, 0x00, 0xFF, 0xFC, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ReadCommandTest, RetrieveHardwareVersionFrame) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0xA5, 0x05, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0x05, 0x00, 0xFF, 0xFB, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(ReadCommandTest, RetrieveErrorCountsFrame) {
+  TestableJbdBmsBle bms;
+  auto f = bms.build_frame_(0xA5, 0xAA, nullptr, 0);
+
+  // clang-format off
+  const std::vector<uint8_t> expected = {
+      0xDD, 0xA5, 0xAA, 0x00, 0xFF, 0x56, 0x77,
+  };
+  // clang-format on
+  EXPECT_EQ(f, expected);
 }
 
 }  // namespace esphome::jbd_bms_ble::testing

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -58,6 +58,33 @@ jbd_bms:
     rx_timeout: 150ms
     # flow_control_pin: GPIO12
 
+button:
+  - platform: jbd_bms_ble
+    jbd_bms_ble_id: bms0
+    retrieve_hardware_version:
+      name: "${bms0} retrieve hardware version"
+    retrieve_error_counts:
+      name: "${bms0} retrieve error counts"
+    force_soc_reset:
+      name: "${bms0} force soc reset"
+    automatic_balancing:
+      name: "${bms0} automatic balancing"
+    clear_alarm:
+      name: "${bms0} clear alarm"
+
+  - platform: jbd_bms
+    jbd_bms_id: bms1
+    retrieve_hardware_version:
+      name: "${bms1} retrieve hardware version"
+    retrieve_error_counts:
+      name: "${bms1} retrieve error counts"
+    force_soc_reset:
+      name: "${bms1} force soc reset"
+    automatic_balancing:
+      name: "${bms1} automatic balancing"
+    clear_alarm:
+      name: "${bms1} clear alarm"
+
 sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -152,12 +152,56 @@ class TestButtonConstants:
         assert button.CONF_RETRIEVE_HARDWARE_VERSION in button.BUTTONS
         assert button.CONF_RETRIEVE_ERROR_COUNTS in button.BUTTONS
         assert button.CONF_FORCE_SOC_RESET in button.BUTTONS
-        assert len(button.BUTTONS) == 3
+        assert button.CONF_AUTOMATIC_BALANCING in button.BUTTONS
+        assert button.CONF_CLEAR_ALARM in button.BUTTONS
+        assert len(button.BUTTONS) == 5
 
-    def test_button_addresses_are_unique(self):
-        addresses = list(button.BUTTONS.values())
-        assert len(addresses) == len(set(addresses))
+    def test_button_payloads(self):
+        assert button.BUTTONS[button.CONF_FORCE_SOC_RESET] == (
+            button.JBD_CMD_WRITE,
+            0x0A,
+            [0x01, 0x00],
+        )
+        assert button.BUTTONS[button.CONF_AUTOMATIC_BALANCING] == (
+            button.JBD_CMD_WRITE,
+            0x0A,
+            [0x07, 0x00],
+        )
+        assert button.BUTTONS[button.CONF_CLEAR_ALARM] == (
+            button.JBD_CMD_WRITE,
+            0x0A,
+            [0x04, 0x00],
+        )
+        assert button.BUTTONS[button.CONF_RETRIEVE_HARDWARE_VERSION] == (
+            button.JBD_CMD_READ,
+            0x05,
+            [],
+        )
 
     def test_ble_buttons_dict(self):
         assert ble_button.CONF_RETRIEVE_HARDWARE_VERSION in ble_button.BUTTONS
-        assert len(ble_button.BUTTONS) == 3
+        assert ble_button.CONF_AUTOMATIC_BALANCING in ble_button.BUTTONS
+        assert ble_button.CONF_CLEAR_ALARM in ble_button.BUTTONS
+        assert len(ble_button.BUTTONS) == 5
+
+    def test_ble_button_payloads(self):
+        assert ble_button.BUTTONS[ble_button.CONF_FORCE_SOC_RESET] == (
+            ble_button.JBD_CMD_WRITE,
+            0x0A,
+            [0x01, 0x00],
+        )
+        assert ble_button.BUTTONS[ble_button.CONF_AUTOMATIC_BALANCING] == (
+            ble_button.JBD_CMD_WRITE,
+            0x0A,
+            [0x07, 0x00],
+        )
+        assert ble_button.BUTTONS[ble_button.CONF_CLEAR_ALARM] == (
+            ble_button.JBD_CMD_WRITE,
+            0x0A,
+            [0x04, 0x00],
+        )
+        assert ble_button.BUTTONS[ble_button.CONF_RETRIEVE_HARDWARE_VERSION] == (
+            ble_button.JBD_CMD_READ,
+            0x05,
+            [],
+        )


### PR DESCRIPTION
## Summary

- Adds three new write-command button entities to both `jbd_bms` and `jbd_bms_ble` components:
  - `automatic_balancing` — writes `0x0700` to register `0x0A`
  - `clear_alarm` — writes `0x0400` to register `0x0A`
- Updates example YAMLs and adds schema/payload tests

## Test plan

- [ ] `pytest tests/test_component_schemas.py` — new `test_write_buttons_dict`, `test_write_button_payloads` and BLE equivalents pass
- [ ] Verify each button generates the correct raw BLE/UART frame on hardware