### PR TITLE
Refactor MAC address to use secrets.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -453,7 +453,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > secrets.yaml
           for YAML in esp*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -461,7 +461,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > tests/secrets.yaml
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -512,7 +512,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > secrets.yaml
           for YAML in esp*faker.yaml esp32-ble-example-multiple-devices.yaml; do
             esphome -s external_components_source components compile $YAML
           done
@@ -522,7 +522,7 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -446,7 +446,7 @@ jobs:
         run: |
           . venv/bin/activate
           for YAML in $(grep -l "^packages:" *.yaml); do
-            yq -i -y '.packages = "!include packages.local.yaml"' $YAML
+            yq -i -Y '.packages = "!include packages.local.yaml"' $YAML
             sed -i "s/'!include packages.local.yaml'/!include packages.local.yaml/" $YAML
           done
 
@@ -489,7 +489,7 @@ jobs:
         run: |
           . venv/bin/activate
           for YAML in $(grep -l "^packages:" *.yaml); do
-            yq -i -y '.packages = "!include packages.local.yaml"' $YAML
+            yq -i -Y '.packages = "!include packages.local.yaml"' $YAML
             sed -i "s/'!include packages.local.yaml'/!include packages.local.yaml/" $YAML
           done
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,20 @@ wifi_password: MY_WIFI_PASSWORD
 mqtt_host: MY_MQTT_HOST
 mqtt_username: MY_MQTT_USERNAME
 mqtt_password: MY_MQTT_PASSWORD
+
+# Required for the BLE examples only. Use the MAC address of your BMS.
+# The esp32-ble-example-multiple-devices.yaml additionally expects a bms1_mac_address.
+bms0_mac_address: 70:3e:97:07:c0:3e
+bms1_mac_address: 70:3e:97:07:c0:3f
 EOF
 
 # Validate the configuration, create a binary, upload it, and start logs
-# If you use a esp8266 run the esp8266-examle.yaml
+# If you use an esp8266 run the esp8266-example.yaml
 esphome run esp32-example.yaml
+
+# To monitor a JBD-BMS via Bluetooth Low Energy run the esp32-ble-example.yaml
+# instead. Set bms0_mac_address in your secrets.yaml to your BMS' MAC address.
+esphome run esp32-ble-example.yaml
 
 ```
 

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -4,8 +4,6 @@ substitutions:
   bms1: "bms1"
   device_description: "Monitor and control a Xiaoxiang Battery Management System (JBD-BMS) via BLE"
   external_components_source: github://syssi/esphome-jbd-bms@main
-  bms0_mac_address: 70:3e:97:07:c0:3e
-  bms1_mac_address: 70:3e:97:07:c0:3f
 
 esphome:
   name: ${name}
@@ -60,9 +58,9 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${bms0_mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
-  - mac_address: ${bms1_mac_address}
+  - mac_address: !secret bms1_mac_address
     id: client1
 
 jbd_bms_ble:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: jbd-bms-ble
   device_description: "Monitor and control a Xiaoxiang Battery Management System (JBD-BMS) via BLE"
   external_components_source: github://syssi/esphome-jbd-bms@main
-  # BMS mac address ought to live in your secrets.yaml file.
 
 esphome:
   name: ${name}
@@ -74,7 +73,7 @@ esp32_ble_tracker:
 
 ble_client:
   - id: client0
-    mac_address: !secret jbd_bms0_mac
+    mac_address: !secret bms0_mac_address
 
 jbd_bms_ble:
   - id: bms0

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -74,7 +74,7 @@ esp32_ble_tracker:
 
 ble_client:
   - id: client0
-    mac_address: !secret jbd_bms0_mac_addr
+    mac_address: !secret jbd_bms0_mac
 
 jbd_bms_ble:
   - id: bms0

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: jbd-bms-ble
   device_description: "Monitor and control a Xiaoxiang Battery Management System (JBD-BMS) via BLE"
   external_components_source: github://syssi/esphome-jbd-bms@main
-  mac_address: 70:3e:97:07:c0:3e
+  # BMS mac address ought to live in your secrets.yaml file.
 
 esphome:
   name: ${name}
@@ -74,7 +74,7 @@ esp32_ble_tracker:
 
 ble_client:
   - id: client0
-    mac_address: ${mac_address}
+    mac_address: !secret jbd_bms0_mac_addr
 
 jbd_bms_ble:
   - id: bms0

--- a/tests/esp32-ble-example-faker-auth-flow.yaml
+++ b/tests/esp32-ble-example-faker-auth-flow.yaml
@@ -37,7 +37,7 @@
 
 ble_client:
   - id: client0
-    mac_address: "10:a5:62:32:75:36"
+    mac_address: !secret bms0_mac_address
 
 jbd_bms_ble:
   - id: bms0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -40,7 +40,7 @@ esp32_ble_tracker:
 
 ble_client:
   - id: client0
-    mac_address: 70:3e:97:07:c0:3e
+    mac_address: !secret bms0_mac_address
 
 jbd_bms_ble:
   - id: bms0

--- a/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
+++ b/yaml-snippets/esp32-ble-deepsleep-limit-charging-automation.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: jbd-bms-ble
   device_description: "Monitor and control a Xiaoxiang Battery Management System (JBD-BMS) via BLE"
   external_components_source: github://syssi/esphome-jbd-bms@main
-  mac_address: 70:3e:97:07:c0:3e
 
 esphome:
   name: ${name}
@@ -54,7 +53,7 @@ esp32_ble_tracker:
 
 ble_client:
   - id: client0
-    mac_address: ${mac_address}
+    mac_address: !secret bms0_mac_address
 
 jbd_bms_ble:
   - id: bms0


### PR DESCRIPTION
Updated MAC address handling to use secrets.yaml

This has dual benefits:
1. No publicly visible mac addresses info
2. Truly portable and independent package. Can live online and !include directly.