### PR TITLE
Remove unused locally defined unit constants

### DIFF
--- a/components/jbd_bms/sensor.py
+++ b/components/jbd_bms/sensor.py
@@ -75,8 +75,6 @@ ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_BALANCER_STATUS_BITMASK = "mdi:seesaw"
 ICON_SOFTWARE_VERSION = "mdi:numeric"
 
-UNIT_SECONDS = "s"
-UNIT_HOURS = "h"
 UNIT_AMPERE_HOURS = "Ah"
 
 CELLS = [f"cell_voltage_{i}" for i in range(1, 33)]

--- a/components/jbd_bms_ble/sensor.py
+++ b/components/jbd_bms_ble/sensor.py
@@ -75,8 +75,6 @@ ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_BALANCER_STATUS_BITMASK = "mdi:seesaw"
 ICON_SOFTWARE_VERSION = "mdi:numeric"
 
-UNIT_SECONDS = "s"
-UNIT_HOURS = "h"
 UNIT_AMPERE_HOURS = "Ah"
 
 CELLS = [f"cell_voltage_{i}" for i in range(1, 33)]


### PR DESCRIPTION
## Summary

The `jbd_bms` and `jbd_bms_ble` sensor platforms defined local `UNIT_SECONDS` and `UNIT_HOURS` constants that are not referenced anywhere. The canonical `UNIT_SECOND` and `UNIT_HOUR` are available in `esphome.const`. This removes the unused duplicates.

| Local definition | Status |
|---|---|
| `UNIT_SECONDS = "s"` | removed (unused; `UNIT_SECOND` exists in `esphome.const`) |
| `UNIT_HOURS = "h"` | removed (unused; `UNIT_HOUR` exists in `esphome.const`) |

**Affected files:** `jbd_bms/sensor`, `jbd_bms_ble/sensor`

No functional change.