### PR TITLE
Replace synthetic frames with real JBD-UP16S020 captures (jbd_bms_up)

### DIFF
--- a/tests/components/jbd_bms_up/common.h
+++ b/tests/components/jbd_bms_up/common.h
@@ -9,6 +9,13 @@ class TestableJbdBmsUp : public JbdBmsUp {
  public:
   using JbdBmsUp::build_frame_;
   using JbdBmsUp::parse_byte_;
+  using JbdBmsUp::rx_buffer_;
+
+  void feed_frame(const std::vector<uint8_t> &frame) {
+    for (uint8_t b : frame)
+      parse_byte_(b);
+    rx_buffer_.clear();
+  }
 };
 
 }  // namespace esphome::jbd_bms_up::testing

--- a/tests/components/jbd_bms_up/frames.h
+++ b/tests/components/jbd_bms_up/frames.h
@@ -7,118 +7,161 @@ namespace esphome::jbd_bms_up::testing {
 #ifndef JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 #define JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 
-// ── Pack status response (0x1000) ─────────────────────────────────────────────
+// ── Pack status response addr=1 (0x1000) ──────────────────────────────────────
 //
-// Real hardware capture: UP16S020, addr=1, 16S LiFePO4 100Ah 48V rack battery.
+// Real hardware capture: JBD-UP16S020, addr=1, 16S LiFePO4 100Ah 48V.
 // Full frame: header[8] + payload[158] + CRC[2] = 168B total.
-// CRC16 (Modbus, LSB-first): 0x54E2 → bytes 0xE2, 0x54.
+// Source: docs/pdus/JBD-UP16S020-two-devices.txt
 //
 // Decoded key values:
-//   total_voltage:         52.90 V    current:               0.00 A
-//   state_of_charge:       45.19 %    capacity_remaining:   45.19 Ah
+//   total_voltage:         53.17 V    current:               0.00 A
+//   state_of_charge:       60.95 %    capacity_remaining:   60.95 Ah
 //   nominal_capacity:     100.00 Ah   charging_cycles:          12
-//   mosfet_temperature:    25.6 °C    ambient_temperature:   27.4 °C
+//   mosfet_temperature:    21.0 °C    ambient_temperature:   22.6 °C
 //   operation_status:      0 (Idle)   state_of_health:       100 %
-//   protect_bitmask:       0          errors_bitmask:            0
 //   MOSFET status:         0x0003     charging: true, discharging: true
-//   max_voltage_cell:      1          max_cell_voltage:      3.307 V
-//   min_voltage_cell:      2          min_cell_voltage:      3.306 V
-//   avg_cell_voltage:      3.306 V    delta_cell_voltage:    0.001 V
-//   battery_strings:       16
-//   cell[0]:  3.307 V  cell[3]:  3.307 V  cell[9]:  3.307 V  cell[15]: 3.307 V
-//   temp[0..3]: 26.0, 25.4, 26.2, 26.4 °C
-//   device_model: "JBD48100000" (null-padded to 30 bytes)
-//
-// Payload offset map:
-//   [0-1]   total_voltage ×0.01 V         [2-3]   reserved
-//   [4-7]   current 32-bit (val-300000)×0.01 A
-//   [8-9]   state_of_charge ×0.01 %       [10-11] capacity_remaining ×0.01 Ah
-//   [12-13] nominal_capacity ×0.01 Ah     [14-15] reserved
-//   [16-17] mosfet_temperature (val-500)×0.1 °C
-//   [18-19] ambient_temperature (val-500)×0.1 °C
-//   [20-21] operation_status              [22-23] state_of_health %
-//   [24-27] protect_bitmask 32-bit        [28-31] errors_bitmask 32-bit
-//   [32-33] MOSFET status (bit0=DSG, bit1=CHG, bit2=precharge)
-//   [34-35] reserved                      [36-37] charging_cycles
-//   [38-39] max_voltage_cell index        [40-41] max_cell_voltage ×0.001 V
-//   [42-43] min_voltage_cell index        [44-45] min_cell_voltage ×0.001 V
-//   [46-47] avg_cell_voltage ×0.001 V     [48-65] reserved (18 bytes)
-//   [66-67] num_cells                     [68+]   cell voltages (×0.001 V each)
-//   [68+2n] num_temperature_sensors       [70+2n] temperatures (val-500)×0.1 °C
-//   [+6]    reserved                      [+30]   device_model string
+//   max_voltage_cell:      3 (1-idx)  max_cell_voltage:      3.331 V
+//   min_voltage_cell:      8 (1-idx)  min_cell_voltage:      3.317 V
+//   avg_cell_voltage:      3.323 V    delta_cell_voltage:    0.014 V
+//   battery_strings:       16         temp[0..3]: 20.9, 20.4, 21.0, 21.2 °C
+//   device_model:          "JBD48100000"
 
 // clang-format off
 static const std::vector<uint8_t> PACK_STATUS_RESPONSE = {
     // header: addr=1, FC=0x78, start=0x1000, end=0x10A0, data_len=158
     0x01, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x9e,
-    // data[0-7]: total_voltage=5290(52.90V), reserved, current=300000(0.00A)
-    0x14, 0xaa, 0x00, 0x00, 0x00, 0x04, 0x93, 0xe0,
-    // data[8-15]: soc=4519(45.19%), cap_rem=4519, nom_cap=10000(100Ah), reserved
-    0x11, 0xa7, 0x11, 0xa7, 0x27, 0x10, 0x27, 0x10,
-    // data[16-23]: mosfet_temp=756(25.6°C), amb_temp=774(27.4°C), op=0(Idle), soh=100
-    0x02, 0xf4, 0x03, 0x06, 0x00, 0x00, 0x00, 0x64,
+    // data[0-7]: total_voltage=5317(53.17V), reserved, current=300000(0.00A)
+    0x14, 0xc5, 0x00, 0x00, 0x00, 0x04, 0x93, 0xe0,
+    // data[8-15]: soc=6095(60.95%), cap_rem=6095, nom_cap=10000(100Ah), reserved
+    0x17, 0xcf, 0x17, 0xcf, 0x27, 0x10, 0x27, 0x10,
+    // data[16-23]: mosfet_temp=710(21.0°C), amb_temp=726(22.6°C), op=0(Idle), soh=100
+    0x02, 0xc6, 0x02, 0xd6, 0x00, 0x00, 0x00, 0x64,
     // data[24-31]: protect_bitmask=0, errors_bitmask=0
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    // data[32-37]: mos=0x0003(CHG+DSG), reserved, cycles=12
-    0x00, 0x03, 0x00, 0x04, 0x00, 0x0c,
-    // data[38-39]: max_voltage_cell index=1
-    0x00, 0x01,
-    // data[40-41]: max_cell_voltage=3307mV(3.307V)
-    0x0c, 0xeb,
-    // data[42-43]: min_voltage_cell index=2
-    0x00, 0x02,
-    // data[44-45]: min_cell_voltage=3306mV(3.306V)
-    0x0c, 0xea,
-    // data[46-47]: avg_cell_voltage=3306mV(3.306V)
-    0x0c, 0xea,
+    // data[32-39]: mos=0x0003(CHG+DSG), reserved, cycles=12, max_cell_idx=3
+    0x00, 0x03, 0x00, 0x04, 0x00, 0x0c, 0x00, 0x03,
+    // data[40-47]: max_cell_v=3331mV, min_cell_idx=8, min_cell_v=3317mV, avg=3323mV
+    0x0d, 0x03, 0x00, 0x08, 0x0c, 0xf5, 0x0c, 0xfb,
     // data[48-65]: reserved (18 bytes)
-    0x00, 0x04, 0x02, 0xfc, 0x00, 0x02, 0x02, 0xf2,
-    0x02, 0xf8, 0x02, 0x48, 0x07, 0xd0, 0x01, 0xc0,
-    0x07, 0xd0,
-    // data[66-67]: num_cells=16
-    0x00, 0x10,
-    // data[68-99]: 16 cell voltages (mV, 0-indexed)
-    0x0c, 0xeb,  // cell[0]  = 3307 mV = 3.307 V
-    0x0c, 0xea,  // cell[1]  = 3306 mV = 3.306 V
-    0x0c, 0xea,  // cell[2]  = 3306 mV
-    0x0c, 0xeb,  // cell[3]  = 3307 mV
-    0x0c, 0xea,  // cell[4]  = 3306 mV
-    0x0c, 0xea,  // cell[5]  = 3306 mV
-    0x0c, 0xea,  // cell[6]  = 3306 mV
-    0x0c, 0xea,  // cell[7]  = 3306 mV
-    0x0c, 0xea,  // cell[8]  = 3306 mV
-    0x0c, 0xeb,  // cell[9]  = 3307 mV
-    0x0c, 0xeb,  // cell[10] = 3307 mV
-    0x0c, 0xeb,  // cell[11] = 3307 mV
-    0x0c, 0xea,  // cell[12] = 3306 mV
-    0x0c, 0xea,  // cell[13] = 3306 mV
-    0x0c, 0xea,  // cell[14] = 3306 mV
-    0x0c, 0xeb,  // cell[15] = 3307 mV
-    // data[100-101]: num_temperature_sensors=4
-    0x00, 0x04,
-    // data[102-109]: 4 temperatures (26.0, 25.4, 26.2, 26.4 °C)
-    0x02, 0xf8,  // temp[0] = 760 → (760-500)×0.1 = 26.0 °C
-    0x02, 0xf2,  // temp[1] = 754 → 25.4 °C
-    0x02, 0xfa,  // temp[2] = 762 → 26.2 °C
-    0x02, 0xfc,  // temp[3] = 764 → 26.4 °C
-    // data[110-115]: reserved (6 bytes, skipped after temperatures)
-    0x00, 0x00, 0x00, 0x00, 0x0c, 0x04,
-    // data[116-145]: device_model "JBD48100000" + null padding (30 bytes)
-    0x4a, 0x42, 0x44, 0x34, 0x38, 0x31, 0x30, 0x30,  // "JBD48100"
-    0x30, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00,  // "000" + padding
+    0x00, 0x04, 0x02, 0xc8, 0x00, 0x02, 0x02, 0xc0,
+    0x02, 0xc4, 0x02, 0x48, 0x07, 0xd0, 0x01, 0xc0,
+    // data[64-71]: reserved, num_cells=16, cell[0]=3326mV, cell[1]=3318mV
+    0x07, 0xd0, 0x00, 0x10, 0x0c, 0xfe, 0x0c, 0xf6,
+    // data[72-87]: cell[2]=3331V, cell[3]=3318V, cell[4]=3320V, cell[5]=3323V
+    //              cell[6]=3328V, cell[7]=3317V (min), cell[8]=3324V, cell[9]=3323V
+    0x0d, 0x03, 0x0c, 0xf6, 0x0c, 0xf8, 0x0c, 0xfb,
+    0x0d, 0x00, 0x0c, 0xf5, 0x0c, 0xfc, 0x0c, 0xfb,
+    // data[88-103]: cell[10..15], num_temps=4, temp[0]=709(20.9°C)
+    0x0c, 0xfe, 0x0c, 0xfb, 0x0c, 0xfc, 0x0c, 0xfd,
+    0x0c, 0xfd, 0x0c, 0xfa, 0x00, 0x04, 0x02, 0xc5,
+    // data[104-115]: temp[1]=704(20.4°C), temp[2]=710(21.0°C), temp[3]=712(21.2°C), reserved
+    0x02, 0xc0, 0x02, 0xc6, 0x02, 0xc8, 0x00, 0x00,
+    // data[112-127]: reserved, device_model[0..7]="JBD481000"
+    0x00, 0x00, 0x0c, 0x04, 0x4a, 0x42, 0x44, 0x34,
+    // data[128-145]: device_model[8..] "00000" + null padding
+    0x38, 0x31, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // data[144-157]: model padding end + trailing reserved
+    0x00, 0x00, 0x00, 0x02, 0x00, 0x03, 0x5a, 0xa6,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    // data[146-157]: trailing reserved bytes (12 bytes)
-    0x00, 0x02, 0x00, 0x03, 0x5a, 0xa6, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    // CRC16 (LSB-first): 0x54E2
-    0xe2, 0x54,
+    // CRC16 (LSB-first): 0x2E6A
+    0x6a, 0x2e,
 };
 // clang-format on
 
 // Payload only — passed directly to on_pack_status_() in decode tests
 static const std::vector<uint8_t> PACK_STATUS_FRAME(PACK_STATUS_RESPONSE.begin() + 8, PACK_STATUS_RESPONSE.end() - 2);
 
+// ── Pack status response addr=2 (0x1000) ──────────────────────────────────────
+//
+// Real hardware capture: JBD-UP16S020, addr=2, same RS485 bus as addr=1.
+// Full frame: header[8] + payload[150] + CRC[2] = 160B total.
+// Source: docs/pdus/JBD-UP16S020-two-devices.txt
+//
+// Decoded key values:
+//   total_voltage:         53.21 V    current:               0.00 A
+//   state_of_charge:       73.00 %    capacity_remaining:   73.27 Ah
+//   nominal_capacity:     100.00 Ah   charging_cycles:           2
+//   mosfet_temperature:    21.4 °C    ambient_temperature:   23.0 °C
+//   operation_status:      0 (Idle)   state_of_health:       100 %
+//   MOSFET status:         0x0003     charging: true, discharging: true
+//   max_voltage_cell:      4 (1-idx)  max_cell_voltage:      3.329 V
+//   min_voltage_cell:      1 (1-idx)  min_cell_voltage:      3.322 V
+//   avg_cell_voltage:      3.325 V    delta_cell_voltage:    0.007 V
+//   battery_strings:       16         temp[0..3]: 21.4, 21.3, 22.0, 21.8 °C
+//   device_model:          "JBD48100000"
+
+// clang-format off
+static const std::vector<uint8_t> PACK_STATUS_RESPONSE_ADDR2 = {
+    // header: addr=2, FC=0x78, start=0x1000, end=0x10A0, data_len=150
+    0x02, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x96,
+    // data[0-7]: total_voltage=5321(53.21V), reserved, current=300000(0.00A)
+    0x14, 0xc9, 0x14, 0xc9, 0x00, 0x04, 0x93, 0xe0,
+    // data[8-15]: soc=7300(73.00%), cap_rem=7327, nom_cap=10000(100Ah), reserved
+    0x1c, 0x84, 0x1c, 0x9f, 0x27, 0x10, 0x27, 0x10,
+    // data[16-23]: mosfet_temp=714(21.4°C), amb_temp=730(23.0°C), op=0(Idle), soh=100
+    0x02, 0xca, 0x02, 0xda, 0x00, 0x00, 0x00, 0x64,
+    // data[24-31]: protect_bitmask=0, errors_bitmask=0
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // data[32-39]: mos=0x0003(CHG+DSG), reserved, cycles=2, max_cell_idx=4
+    0x00, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x04,
+    // data[40-47]: max_cell_v=3329mV, min_cell_idx=1, min_cell_v=3322mV, avg=3325mV
+    0x0d, 0x01, 0x00, 0x01, 0x0c, 0xfa, 0x0c, 0xfd,
+    // data[48-65]: reserved (18 bytes)
+    0x00, 0x03, 0x02, 0xd0, 0x00, 0x02, 0x02, 0xc9,
+    0x02, 0xcc, 0x02, 0x48, 0x03, 0xe8, 0x01, 0xc0,
+    // data[64-71]: reserved, num_cells=16, cell[0]=3322mV, cell[1]=3327mV
+    0x03, 0xe8, 0x00, 0x10, 0x0c, 0xfa, 0x0c, 0xff,
+    // data[72-87]: cell[2..5], cell[6..9]
+    0x0c, 0xfb, 0x0d, 0x01, 0x0c, 0xff, 0x0c, 0xfc,
+    0x0c, 0xfc, 0x0d, 0x00, 0x0c, 0xfb, 0x0c, 0xfe,
+    // data[88-103]: cell[10..15], num_temps=4, temp[0]=714(21.4°C)
+    0x0d, 0x00, 0x0c, 0xfc, 0x0c, 0xff, 0x0c, 0xfe,
+    0x0d, 0x00, 0x0c, 0xfd, 0x00, 0x04, 0x02, 0xca,
+    // data[104-115]: temp[1]=713(21.3°C), temp[2]=720(22.0°C), temp[3]=718(21.8°C), reserved
+    0x02, 0xc9, 0x02, 0xd0, 0x02, 0xce, 0x00, 0x00,
+    // data[112-127]: reserved, device_model[0..7]="JBD481000"
+    0x00, 0x00, 0x00, 0x04, 0x4a, 0x42, 0x44, 0x34,
+    // data[128-149]: device_model[8..] + null padding + trailing reserved
+    0x38, 0x31, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x02,
+    // CRC16 (LSB-first): 0xC0BC
+    0xbc, 0xc0,
+};
+// clang-format on
+
+static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8, PACK_STATUS_RESPONSE_ADDR2.end() - 2);
+
 #endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
+
+// ── Charging variant ──────────────────────────────────────────────────────────
+// current = +50.00A → val = 305000 = 0x0004A768
+// operation_status = 1 (Charging), MOSFET = 0x0002 (CHG only)
+static std::vector<uint8_t> make_pack_status_charging() {
+  auto f = PACK_STATUS_FRAME;
+  f[4] = 0x00;
+  f[5] = 0x04;
+  f[6] = 0xa7;
+  f[7] = 0x68;  // current=305000
+  f[20] = 0x00;
+  f[21] = 0x01;  // op_status=1
+  f[32] = 0x00;
+  f[33] = 0x02;  // mos=CHG only
+  return f;
+}
+
+// ── Error bitmask variant ─────────────────────────────────────────────────────
+// errors_bitmask = 0x00010001: bit0=cell_overvoltage, bit16=eep_fault
+static std::vector<uint8_t> make_pack_status_with_errors() {
+  auto f = PACK_STATUS_FRAME;
+  f[28] = 0x00;
+  f[29] = 0x01;  // errors high word = 0x0001 (bit16 = EEP fault)
+  f[30] = 0x00;
+  f[31] = 0x01;  // errors low word  = 0x0001 (bit0  = cell overvoltage)
+  return f;
+}
 
 }  // namespace esphome::jbd_bms_up::testing

--- a/tests/components/jbd_bms_up/frames.h
+++ b/tests/components/jbd_bms_up/frames.h
@@ -133,7 +133,8 @@ static const std::vector<uint8_t> PACK_STATUS_RESPONSE_ADDR2 = {
 };
 // clang-format on
 
-static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8, PACK_STATUS_RESPONSE_ADDR2.end() - 2);
+static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8,
+                                                          PACK_STATUS_RESPONSE_ADDR2.end() - 2);
 
 #endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 

--- a/tests/components/jbd_bms_up/request_frame_test.cpp
+++ b/tests/components/jbd_bms_up/request_frame_test.cpp
@@ -7,82 +7,71 @@ namespace esphome::jbd_bms_up::testing {
 // ── CRC16 ─────────────────────────────────────────────────────────────────────
 //
 // CRC16: poly=0xA001, init=0xFFFF, LSB-first (Modbus-style).
-// Expected values verified against hardware captures in:
-//   https://gist.github.com/PhracturedBlue/7ef619594eaa4c27f4ff068b461865b8
+// Expected values verified against real hardware captures in:
+//   docs/pdus/JBD-UP16S020-two-devices.txt
 
-TEST(CRC16Test, PackStatusRequest) {
-  // Request: 01 78 10 00 10 a0 00 00 | 7f b2
-  // CRC stored LSB-first: 0x7F, 0xB2 → value = 0x7F | (0xB2 << 8) = 0xB27F
+TEST(CRC16Test, PackStatusRequestAddr1) {
+  // Request addr=1: 01 78 10 00 10 a0 00 00 | 7f b2
   const uint8_t data[] = {0x01, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x00};
   EXPECT_EQ(crc16(data, 8), 0xB27F);
 }
 
+TEST(CRC16Test, PackStatusRequestAddr2) {
+  // Request addr=2: 02 78 10 00 10 a0 00 00 | 3f a7
+  const uint8_t data[] = {0x02, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x00};
+  EXPECT_EQ(crc16(data, 8), 0xA73F);
+}
+
 TEST(CRC16Test, PackParametersRequest) {
-  // Request: 01 78 1c 00 1c a0 00 00 | 7c 2e
-  // CRC: 0x7C | (0x2E << 8) = 0x2E7C
+  // Request addr=1: 01 78 1c 00 1c a0 00 00 | 7c 2e
   const uint8_t data[] = {0x01, 0x78, 0x1c, 0x00, 0x1c, 0xa0, 0x00, 0x00};
   EXPECT_EQ(crc16(data, 8), 0x2E7C);
 }
 
 TEST(CRC16Test, DatetimeGetRequest) {
-  // Request: 01 78 28 00 28 0f 00 00 | 46 4b
-  // CRC: 0x46 | (0x4B << 8) = 0x4B46
+  // Request addr=1: 01 78 28 00 28 0f 00 00 | 46 4b
   const uint8_t data[] = {0x01, 0x78, 0x28, 0x00, 0x28, 0x0f, 0x00, 0x00};
   EXPECT_EQ(crc16(data, 8), 0x4B46);
 }
 
 // ── build_frame_ — pack status poll ──────────────────────────────────────────
 //
-// Pack status request (addr=1, FC=0x78, start=0x1000, end=0x10A0, no payload):
-//   01 78 10 00 10 a0 00 00 7f b2
-// Source: gist hardware capture.
+// Request frames verified against real hardware captures.
 
-TEST(BuildFrameTest, PackStatusRequest) {
+TEST(BuildFrameTest, PackStatusRequestAddr1) {
   TestableJbdBmsUp bus;
   auto f = bus.build_frame_(0x01, 0x78, 0x1000, 0x10A0);
-
-  // clang-format off
   const std::vector<uint8_t> expected = {
       0x01, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x00, 0x7f, 0xb2,
   };
-  // clang-format on
+  EXPECT_EQ(f, expected);
+}
+
+TEST(BuildFrameTest, PackStatusRequestAddr2) {
+  TestableJbdBmsUp bus;
+  auto f = bus.build_frame_(0x02, 0x78, 0x1000, 0x10A0);
+  const std::vector<uint8_t> expected = {
+      0x02, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x00, 0x3f, 0xa7,
+  };
   EXPECT_EQ(f, expected);
 }
 
 TEST(BuildFrameTest, PackParametersRequest) {
-  // Request: 01 78 1c 00 1c a0 00 00 7c 2e
   TestableJbdBmsUp bus;
   auto f = bus.build_frame_(0x01, 0x78, 0x1C00, 0x1CA0);
-
-  // clang-format off
   const std::vector<uint8_t> expected = {
       0x01, 0x78, 0x1c, 0x00, 0x1c, 0xa0, 0x00, 0x00, 0x7c, 0x2e,
   };
-  // clang-format on
   EXPECT_EQ(f, expected);
 }
 
 TEST(BuildFrameTest, DatetimeGetRequest) {
-  // Request: 01 78 28 00 28 0f 00 00 46 4b
   TestableJbdBmsUp bus;
   auto f = bus.build_frame_(0x01, 0x78, 0x2800, 0x280F);
-
-  // clang-format off
   const std::vector<uint8_t> expected = {
       0x01, 0x78, 0x28, 0x00, 0x28, 0x0f, 0x00, 0x00, 0x46, 0x4b,
   };
-  // clang-format on
   EXPECT_EQ(f, expected);
-}
-
-TEST(BuildFrameTest, Address2Request) {
-  // Same poll but for address 2 — CRC must change
-  TestableJbdBmsUp bus;
-  auto f1 = bus.build_frame_(0x01, 0x78, 0x1000, 0x10A0);
-  auto f2 = bus.build_frame_(0x02, 0x78, 0x1000, 0x10A0);
-  // Different address → different CRC
-  EXPECT_NE(f1[8], f2[8]);
-  EXPECT_EQ(f2[0], 0x02);
 }
 
 // ── build_frame_ — frame structure ────────────────────────────────────────────
@@ -90,7 +79,6 @@ TEST(BuildFrameTest, Address2Request) {
 TEST(BuildFrameTest, ReadFrameLength) {
   TestableJbdBmsUp bus;
   auto f = bus.build_frame_(0x01, 0x78, 0x1000, 0x10A0);
-  // 8 header + 0 payload + 2 CRC = 10 bytes
   EXPECT_EQ(f.size(), 10u);
 }
 
@@ -102,16 +90,13 @@ TEST(BuildFrameTest, ReadFrameDataLenZero) {
 }
 
 TEST(BuildFrameTest, WriteFrameWithPayload) {
-  // MOS control: 01 79 29 02 29 04 00 06 11 4a 42 44 00 01 [CRC]
+  // MOS control: addr=1, FC=0x79, start=0x2902, end=0x2904, payload=6 bytes
   TestableJbdBmsUp bus;
   const std::vector<uint8_t> payload = {0x11, 0x4a, 0x42, 0x44, 0x00, 0x01};
   auto f = bus.build_frame_(0x01, 0x79, 0x2902, 0x2904, payload);
-  // 8 header + 6 payload + 2 CRC = 16 bytes
   EXPECT_EQ(f.size(), 16u);
-  // data_len field = 0x0006
   EXPECT_EQ(f[6], 0x00);
   EXPECT_EQ(f[7], 0x06);
-  // payload starts at byte 8
   EXPECT_EQ(f[8], 0x11);
   EXPECT_EQ(f[9], 0x4a);
   EXPECT_EQ(f[10], 0x42);
@@ -119,9 +104,6 @@ TEST(BuildFrameTest, WriteFrameWithPayload) {
 }
 
 // ── parse_byte_ — full frame roundtrip ────────────────────────────────────────
-//
-// Feed the captured pack status response byte by byte into parse_byte_,
-// verify that on_jbd_bms_up_data is called exactly once with the right args.
 
 class MockDevice : public JbdBmsUpDevice {
  public:
@@ -137,15 +119,12 @@ class MockDevice : public JbdBmsUpDevice {
   int call_count{0};
 };
 
-TEST(ParseByteTest, PackStatusFullFrame) {
-  using esphome::jbd_bms_up::testing::PACK_STATUS_RESPONSE;
-
+TEST(ParseByteTest, PackStatusFullFrameAddr1) {
   TestableJbdBmsUp bus;
   MockDevice device;
   device.set_address(0x01);
   bus.register_device(&device);
 
-  // Feed all bytes — last byte triggers CRC check and dispatch
   bool any_reset = false;
   for (size_t i = 0; i < PACK_STATUS_RESPONSE.size(); i++) {
     bool ok = bus.parse_byte_(PACK_STATUS_RESPONSE[i]);
@@ -160,58 +139,79 @@ TEST(ParseByteTest, PackStatusFullFrame) {
   EXPECT_EQ(device.received_data.size(), 158u);
 }
 
+TEST(ParseByteTest, PackStatusFullFrameAddr2) {
+  TestableJbdBmsUp bus;
+  MockDevice device;
+  device.set_address(0x02);
+  bus.register_device(&device);
+
+  bool any_reset = false;
+  for (size_t i = 0; i < PACK_STATUS_RESPONSE_ADDR2.size(); i++) {
+    bool ok = bus.parse_byte_(PACK_STATUS_RESPONSE_ADDR2[i]);
+    if (!ok && i < PACK_STATUS_RESPONSE_ADDR2.size() - 1)
+      any_reset = true;
+  }
+
+  EXPECT_FALSE(any_reset) << "Buffer was unexpectedly reset mid-frame";
+  EXPECT_EQ(device.call_count, 1);
+  EXPECT_EQ(device.received_function, 0x78);
+  EXPECT_EQ(device.received_start_addr, 0x1000);
+  EXPECT_EQ(device.received_data.size(), 150u);
+}
+
+TEST(ParseByteTest, MultiDeviceAddressFiltering) {
+  // Two devices on the same bus — each frame must only be dispatched to the
+  // device whose address matches the frame's address byte.
+  // feed_frame() mirrors parse_read_(): clears rx_buffer_ after each complete frame.
+  TestableJbdBmsUp bus;
+  MockDevice device1, device2;
+  device1.set_address(0x01);
+  device2.set_address(0x02);
+  bus.register_device(&device1);
+  bus.register_device(&device2);
+
+  // addr=1 frame → only device1 receives it
+  bus.feed_frame(PACK_STATUS_RESPONSE);
+  EXPECT_EQ(device1.call_count, 1);
+  EXPECT_EQ(device2.call_count, 0);
+
+  // addr=2 frame → only device2 receives it
+  bus.feed_frame(PACK_STATUS_RESPONSE_ADDR2);
+  EXPECT_EQ(device1.call_count, 1);  // unchanged
+  EXPECT_EQ(device2.call_count, 1);
+}
+
+TEST(ParseByteTest, Addr1ResponseNotDispatchedToAddr2Device) {
+  // A device registered at addr=2 must not receive frames addressed to addr=1.
+  TestableJbdBmsUp bus;
+  MockDevice device2;
+  device2.set_address(0x02);
+  bus.register_device(&device2);
+
+  bus.feed_frame(PACK_STATUS_RESPONSE);
+
+  EXPECT_EQ(device2.call_count, 0);
+}
+
 TEST(ParseByteTest, InvalidAddressRejected) {
   TestableJbdBmsUp bus;
-  // Address 0xFF > 247: should be rejected at byte 0
   bool ok = bus.parse_byte_(0xFF);
   EXPECT_FALSE(ok);
 }
 
 TEST(ParseByteTest, WrongCrcRejected) {
-  using esphome::jbd_bms_up::testing::PACK_STATUS_RESPONSE;
-
   TestableJbdBmsUp bus;
   MockDevice device;
   device.set_address(0x01);
   bus.register_device(&device);
 
-  // Corrupt the CRC
   std::vector<uint8_t> corrupted = PACK_STATUS_RESPONSE;
   corrupted[corrupted.size() - 1] ^= 0xFF;
 
   for (uint8_t b : corrupted)
     bus.parse_byte_(b);
 
-  EXPECT_EQ(device.call_count, 0) << "Corrupted frame should not be dispatched";
+  EXPECT_EQ(device.call_count, 0) << "Corrupted frame must not be dispatched";
 }
-
-// ── @TODO: missing frame tests ────────────────────────────────────────────────
-//
-// The following frames are documented in the gist but no complete byte captures
-// are available yet. Add tests once hardware captures with verified CRC exist.
-//
-// @TODO Pack Parameters response (0x1C00, FC=0x78):
-//   Request:  01 78 1c 00 1c a0 00 00 7c 2e
-//   Response: 136 bytes — balance voltage, thermal thresholds, BMS code
-//   Needs: frames for on_pack_parameters_() decoder (not yet implemented)
-//
-// @TODO Alternate Pack Status (FC=0x45, addr=0x0000):
-//   Request:  01 45 00 00 00 54 00 00 d4 d3
-//   Response: 124 bytes — cell voltages, temperatures, capacities via 0x45
-//   Needs: on_jbd_bms_up_data dispatch for FC=0x45
-//
-// @TODO DateTime Read response (0x2800, FC=0x78):
-//   Request:  01 78 28 00 28 0f 00 00 46 4b
-//   Response: 01 78 28 00 28 0f 00 0c [12 bytes: year,month,day,h,m,s] [CRC]
-//   Needs: datetime sensor entities (not yet implemented)
-//
-// @TODO DateTime Write (0x2800, FC=0x79):
-//   Request:  01 79 28 00 28 0c 00 10 11 4a 42 44 [7-byte timestamp] [CRC]
-//   Needs: datetime write button/service (not yet implemented)
-//
-// @TODO MOS Control Write (0x2902, FC=0x79):
-//   Request:  01 79 29 02 29 04 00 06 11 4a 42 44 [bitmask 2B] [CRC]
-//   Example:  01 79 29 02 29 04 00 06 11 4a 42 44 00 01 15 85
-//   Needs: MOS write implementation + switch entities
 
 }  // namespace esphome::jbd_bms_up::testing

--- a/tests/components/jbd_bms_up_pack/frames.h
+++ b/tests/components/jbd_bms_up_pack/frames.h
@@ -7,117 +7,133 @@ namespace esphome::jbd_bms_up::testing {
 #ifndef JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 #define JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 
-// ── Pack status response (0x1000) ─────────────────────────────────────────────
+// ── Pack status response addr=1 (0x1000) ──────────────────────────────────────
 //
-// Real hardware capture: UP16S020, addr=1, 16S LiFePO4 100Ah 48V rack battery.
+// Real hardware capture: JBD-UP16S020, addr=1, 16S LiFePO4 100Ah 48V.
 // Full frame: header[8] + payload[158] + CRC[2] = 168B total.
-// CRC16 (Modbus, LSB-first): 0x54E2 → bytes 0xE2, 0x54.
+// Source: docs/pdus/JBD-UP16S020-two-devices.txt
 //
 // Decoded key values:
-//   total_voltage:         52.90 V    current:               0.00 A
-//   state_of_charge:       45.19 %    capacity_remaining:   45.19 Ah
+//   total_voltage:         53.17 V    current:               0.00 A
+//   state_of_charge:       60.95 %    capacity_remaining:   60.95 Ah
 //   nominal_capacity:     100.00 Ah   charging_cycles:          12
-//   mosfet_temperature:    25.6 °C    ambient_temperature:   27.4 °C
+//   mosfet_temperature:    21.0 °C    ambient_temperature:   22.6 °C
 //   operation_status:      0 (Idle)   state_of_health:       100 %
-//   protect_bitmask:       0          errors_bitmask:            0
 //   MOSFET status:         0x0003     charging: true, discharging: true
-//   max_voltage_cell:      1          max_cell_voltage:      3.307 V
-//   min_voltage_cell:      2          min_cell_voltage:      3.306 V
-//   avg_cell_voltage:      3.306 V    delta_cell_voltage:    0.001 V
-//   battery_strings:       16
-//   cell[0]:  3.307 V  cell[3]:  3.307 V  cell[9]:  3.307 V  cell[15]: 3.307 V
-//   temp[0..3]: 26.0, 25.4, 26.2, 26.4 °C
-//   device_model: "JBD48100000" (null-padded to 30 bytes)
-//
-// Payload offset map:
-//   [0-1]   total_voltage ×0.01 V         [2-3]   reserved
-//   [4-7]   current 32-bit (val-300000)×0.01 A
-//   [8-9]   state_of_charge ×0.01 %       [10-11] capacity_remaining ×0.01 Ah
-//   [12-13] nominal_capacity ×0.01 Ah     [14-15] reserved
-//   [16-17] mosfet_temperature (val-500)×0.1 °C
-//   [18-19] ambient_temperature (val-500)×0.1 °C
-//   [20-21] operation_status              [22-23] state_of_health %
-//   [24-27] protect_bitmask 32-bit        [28-31] errors_bitmask 32-bit
-//   [32-33] MOSFET status (bit0=DSG, bit1=CHG, bit2=precharge)
-//   [34-35] reserved                      [36-37] charging_cycles
-//   [38-39] max_voltage_cell index        [40-41] max_cell_voltage ×0.001 V
-//   [42-43] min_voltage_cell index        [44-45] min_cell_voltage ×0.001 V
-//   [46-47] avg_cell_voltage ×0.001 V     [48-65] reserved (18 bytes)
-//   [66-67] num_cells                     [68+]   cell voltages (×0.001 V each)
-//   [68+2n] num_temperature_sensors       [70+2n] temperatures (val-500)×0.1 °C
-//   [+6]    reserved                      [+30]   device_model string
+//   max_voltage_cell:      3 (1-idx)  max_cell_voltage:      3.331 V
+//   min_voltage_cell:      8 (1-idx)  min_cell_voltage:      3.317 V
+//   avg_cell_voltage:      3.323 V    delta_cell_voltage:    0.014 V
+//   battery_strings:       16         temp[0..3]: 20.9, 20.4, 21.0, 21.2 °C
+//   device_model:          "JBD48100000"
 
 // clang-format off
 static const std::vector<uint8_t> PACK_STATUS_RESPONSE = {
     // header: addr=1, FC=0x78, start=0x1000, end=0x10A0, data_len=158
     0x01, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x9e,
-    // data[0-7]: total_voltage=5290(52.90V), reserved, current=300000(0.00A)
-    0x14, 0xaa, 0x00, 0x00, 0x00, 0x04, 0x93, 0xe0,
-    // data[8-15]: soc=4519(45.19%), cap_rem=4519, nom_cap=10000(100Ah), reserved
-    0x11, 0xa7, 0x11, 0xa7, 0x27, 0x10, 0x27, 0x10,
-    // data[16-23]: mosfet_temp=756(25.6°C), amb_temp=774(27.4°C), op=0(Idle), soh=100
-    0x02, 0xf4, 0x03, 0x06, 0x00, 0x00, 0x00, 0x64,
+    // data[0-7]: total_voltage=5317(53.17V), reserved, current=300000(0.00A)
+    0x14, 0xc5, 0x00, 0x00, 0x00, 0x04, 0x93, 0xe0,
+    // data[8-15]: soc=6095(60.95%), cap_rem=6095, nom_cap=10000(100Ah), reserved
+    0x17, 0xcf, 0x17, 0xcf, 0x27, 0x10, 0x27, 0x10,
+    // data[16-23]: mosfet_temp=710(21.0°C), amb_temp=726(22.6°C), op=0(Idle), soh=100
+    0x02, 0xc6, 0x02, 0xd6, 0x00, 0x00, 0x00, 0x64,
     // data[24-31]: protect_bitmask=0, errors_bitmask=0
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    // data[32-37]: mos=0x0003(CHG+DSG), reserved, cycles=12
-    0x00, 0x03, 0x00, 0x04, 0x00, 0x0c,
-    // data[38-39]: max_voltage_cell index=1
-    0x00, 0x01,
-    // data[40-41]: max_cell_voltage=3307mV(3.307V)
-    0x0c, 0xeb,
-    // data[42-43]: min_voltage_cell index=2
-    0x00, 0x02,
-    // data[44-45]: min_cell_voltage=3306mV(3.306V)
-    0x0c, 0xea,
-    // data[46-47]: avg_cell_voltage=3306mV(3.306V)
-    0x0c, 0xea,
+    // data[32-39]: mos=0x0003(CHG+DSG), reserved, cycles=12, max_cell_idx=3
+    0x00, 0x03, 0x00, 0x04, 0x00, 0x0c, 0x00, 0x03,
+    // data[40-47]: max_cell_v=3331mV, min_cell_idx=8, min_cell_v=3317mV, avg=3323mV
+    0x0d, 0x03, 0x00, 0x08, 0x0c, 0xf5, 0x0c, 0xfb,
     // data[48-65]: reserved (18 bytes)
-    0x00, 0x04, 0x02, 0xfc, 0x00, 0x02, 0x02, 0xf2,
-    0x02, 0xf8, 0x02, 0x48, 0x07, 0xd0, 0x01, 0xc0,
-    0x07, 0xd0,
-    // data[66-67]: num_cells=16
-    0x00, 0x10,
-    // data[68-99]: 16 cell voltages (mV, 0-indexed)
-    0x0c, 0xeb,  // cell[0]  = 3307 mV = 3.307 V
-    0x0c, 0xea,  // cell[1]  = 3306 mV = 3.306 V
-    0x0c, 0xea,  // cell[2]  = 3306 mV
-    0x0c, 0xeb,  // cell[3]  = 3307 mV
-    0x0c, 0xea,  // cell[4]  = 3306 mV
-    0x0c, 0xea,  // cell[5]  = 3306 mV
-    0x0c, 0xea,  // cell[6]  = 3306 mV
-    0x0c, 0xea,  // cell[7]  = 3306 mV
-    0x0c, 0xea,  // cell[8]  = 3306 mV
-    0x0c, 0xeb,  // cell[9]  = 3307 mV
-    0x0c, 0xeb,  // cell[10] = 3307 mV
-    0x0c, 0xeb,  // cell[11] = 3307 mV
-    0x0c, 0xea,  // cell[12] = 3306 mV
-    0x0c, 0xea,  // cell[13] = 3306 mV
-    0x0c, 0xea,  // cell[14] = 3306 mV
-    0x0c, 0xeb,  // cell[15] = 3307 mV
-    // data[100-101]: num_temperature_sensors=4
-    0x00, 0x04,
-    // data[102-109]: 4 temperatures (26.0, 25.4, 26.2, 26.4 °C)
-    0x02, 0xf8,  // temp[0] = 760 → (760-500)×0.1 = 26.0 °C
-    0x02, 0xf2,  // temp[1] = 754 → 25.4 °C
-    0x02, 0xfa,  // temp[2] = 762 → 26.2 °C
-    0x02, 0xfc,  // temp[3] = 764 → 26.4 °C
-    // data[110-115]: reserved (6 bytes, skipped after temperatures)
-    0x00, 0x00, 0x00, 0x00, 0x0c, 0x04,
-    // data[116-145]: device_model "JBD48100000" + null padding (30 bytes)
-    0x4a, 0x42, 0x44, 0x34, 0x38, 0x31, 0x30, 0x30,  // "JBD48100"
-    0x30, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00,  // "000" + padding
+    0x00, 0x04, 0x02, 0xc8, 0x00, 0x02, 0x02, 0xc0,
+    0x02, 0xc4, 0x02, 0x48, 0x07, 0xd0, 0x01, 0xc0,
+    // data[64-71]: reserved, num_cells=16, cell[0]=3326mV, cell[1]=3318mV
+    0x07, 0xd0, 0x00, 0x10, 0x0c, 0xfe, 0x0c, 0xf6,
+    // data[72-87]: cell[2]=3331V, cell[3]=3318V, cell[4]=3320V, cell[5]=3323V
+    //              cell[6]=3328V, cell[7]=3317V (min), cell[8]=3324V, cell[9]=3323V
+    0x0d, 0x03, 0x0c, 0xf6, 0x0c, 0xf8, 0x0c, 0xfb,
+    0x0d, 0x00, 0x0c, 0xf5, 0x0c, 0xfc, 0x0c, 0xfb,
+    // data[88-103]: cell[10..15], num_temps=4, temp[0]=709(20.9°C)
+    0x0c, 0xfe, 0x0c, 0xfb, 0x0c, 0xfc, 0x0c, 0xfd,
+    0x0c, 0xfd, 0x0c, 0xfa, 0x00, 0x04, 0x02, 0xc5,
+    // data[104-115]: temp[1]=704(20.4°C), temp[2]=710(21.0°C), temp[3]=712(21.2°C), reserved
+    0x02, 0xc0, 0x02, 0xc6, 0x02, 0xc8, 0x00, 0x00,
+    // data[112-127]: reserved, device_model[0..7]="JBD481000"
+    0x00, 0x00, 0x0c, 0x04, 0x4a, 0x42, 0x44, 0x34,
+    // data[128-145]: device_model[8..] "00000" + null padding
+    0x38, 0x31, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // data[144-157]: model padding end + trailing reserved
+    0x00, 0x00, 0x00, 0x02, 0x00, 0x03, 0x5a, 0xa6,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    // data[146-157]: trailing reserved bytes (12 bytes)
-    0x00, 0x02, 0x00, 0x03, 0x5a, 0xa6, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    // CRC16 (LSB-first): 0x54E2
-    0xe2, 0x54,
+    // CRC16 (LSB-first): 0x2E6A
+    0x6a, 0x2e,
 };
 // clang-format on
 
 // Payload only — passed directly to on_pack_status_() in decode tests
 static const std::vector<uint8_t> PACK_STATUS_FRAME(PACK_STATUS_RESPONSE.begin() + 8, PACK_STATUS_RESPONSE.end() - 2);
+
+// ── Pack status response addr=2 (0x1000) ──────────────────────────────────────
+//
+// Real hardware capture: JBD-UP16S020, addr=2, same RS485 bus as addr=1.
+// Full frame: header[8] + payload[150] + CRC[2] = 160B total.
+// Source: docs/pdus/JBD-UP16S020-two-devices.txt
+//
+// Decoded key values:
+//   total_voltage:         53.21 V    current:               0.00 A
+//   state_of_charge:       73.00 %    capacity_remaining:   73.27 Ah
+//   nominal_capacity:     100.00 Ah   charging_cycles:           2
+//   mosfet_temperature:    21.4 °C    ambient_temperature:   23.0 °C
+//   operation_status:      0 (Idle)   state_of_health:       100 %
+//   MOSFET status:         0x0003     charging: true, discharging: true
+//   max_voltage_cell:      4 (1-idx)  max_cell_voltage:      3.329 V
+//   min_voltage_cell:      1 (1-idx)  min_cell_voltage:      3.322 V
+//   avg_cell_voltage:      3.325 V    delta_cell_voltage:    0.007 V
+//   battery_strings:       16         temp[0..3]: 21.4, 21.3, 22.0, 21.8 °C
+//   device_model:          "JBD48100000"
+
+// clang-format off
+static const std::vector<uint8_t> PACK_STATUS_RESPONSE_ADDR2 = {
+    // header: addr=2, FC=0x78, start=0x1000, end=0x10A0, data_len=150
+    0x02, 0x78, 0x10, 0x00, 0x10, 0xa0, 0x00, 0x96,
+    // data[0-7]: total_voltage=5321(53.21V), reserved, current=300000(0.00A)
+    0x14, 0xc9, 0x14, 0xc9, 0x00, 0x04, 0x93, 0xe0,
+    // data[8-15]: soc=7300(73.00%), cap_rem=7327, nom_cap=10000(100Ah), reserved
+    0x1c, 0x84, 0x1c, 0x9f, 0x27, 0x10, 0x27, 0x10,
+    // data[16-23]: mosfet_temp=714(21.4°C), amb_temp=730(23.0°C), op=0(Idle), soh=100
+    0x02, 0xca, 0x02, 0xda, 0x00, 0x00, 0x00, 0x64,
+    // data[24-31]: protect_bitmask=0, errors_bitmask=0
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // data[32-39]: mos=0x0003(CHG+DSG), reserved, cycles=2, max_cell_idx=4
+    0x00, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x04,
+    // data[40-47]: max_cell_v=3329mV, min_cell_idx=1, min_cell_v=3322mV, avg=3325mV
+    0x0d, 0x01, 0x00, 0x01, 0x0c, 0xfa, 0x0c, 0xfd,
+    // data[48-65]: reserved (18 bytes)
+    0x00, 0x03, 0x02, 0xd0, 0x00, 0x02, 0x02, 0xc9,
+    0x02, 0xcc, 0x02, 0x48, 0x03, 0xe8, 0x01, 0xc0,
+    // data[64-71]: reserved, num_cells=16, cell[0]=3322mV, cell[1]=3327mV
+    0x03, 0xe8, 0x00, 0x10, 0x0c, 0xfa, 0x0c, 0xff,
+    // data[72-87]: cell[2..5], cell[6..9]
+    0x0c, 0xfb, 0x0d, 0x01, 0x0c, 0xff, 0x0c, 0xfc,
+    0x0c, 0xfc, 0x0d, 0x00, 0x0c, 0xfb, 0x0c, 0xfe,
+    // data[88-103]: cell[10..15], num_temps=4, temp[0]=714(21.4°C)
+    0x0d, 0x00, 0x0c, 0xfc, 0x0c, 0xff, 0x0c, 0xfe,
+    0x0d, 0x00, 0x0c, 0xfd, 0x00, 0x04, 0x02, 0xca,
+    // data[104-115]: temp[1]=713(21.3°C), temp[2]=720(22.0°C), temp[3]=718(21.8°C), reserved
+    0x02, 0xc9, 0x02, 0xd0, 0x02, 0xce, 0x00, 0x00,
+    // data[112-127]: reserved, device_model[0..7]="JBD481000"
+    0x00, 0x00, 0x00, 0x04, 0x4a, 0x42, 0x44, 0x34,
+    // data[128-149]: device_model[8..] + null padding + trailing reserved
+    0x38, 0x31, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x02,
+    // CRC16 (LSB-first): 0xC0BC
+    0xbc, 0xc0,
+};
+// clang-format on
+
+static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8, PACK_STATUS_RESPONSE_ADDR2.end() - 2);
 
 #endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 

--- a/tests/components/jbd_bms_up_pack/frames.h
+++ b/tests/components/jbd_bms_up_pack/frames.h
@@ -133,7 +133,8 @@ static const std::vector<uint8_t> PACK_STATUS_RESPONSE_ADDR2 = {
 };
 // clang-format on
 
-static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8, PACK_STATUS_RESPONSE_ADDR2.end() - 2);
+static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8,
+                                                          PACK_STATUS_RESPONSE_ADDR2.end() - 2);
 
 #endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 

--- a/tests/components/jbd_bms_up_pack/pack_status_test.cpp
+++ b/tests/components/jbd_bms_up_pack/pack_status_test.cpp
@@ -188,10 +188,10 @@ TEST(PackStatusTest, CellVoltageStats) {
   pack.set_delta_cell_voltage_sensor(&delta);
   pack.on_pack_status_(PACK_STATUS_FRAME);
   EXPECT_NEAR(max_v.state, 3.331f, 0.001f);
-  EXPECT_FLOAT_EQ(max_cell.state, 3.0f);   // 1-indexed cell 3
+  EXPECT_FLOAT_EQ(max_cell.state, 3.0f);  // 1-indexed cell 3
   EXPECT_NEAR(avg.state, 3.323f, 0.001f);
   EXPECT_NEAR(min_v.state, 3.317f, 0.001f);
-  EXPECT_FLOAT_EQ(min_cell.state, 8.0f);   // 1-indexed cell 8
+  EXPECT_FLOAT_EQ(min_cell.state, 8.0f);  // 1-indexed cell 8
   EXPECT_NEAR(delta.state, 0.014f, 0.001f);
 }
 
@@ -269,10 +269,10 @@ TEST(PackStatusTest, Addr2CellVoltageStats) {
   pack.set_delta_cell_voltage_sensor(&delta);
   pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
   EXPECT_NEAR(max_v.state, 3.329f, 0.001f);
-  EXPECT_FLOAT_EQ(max_cell.state, 4.0f);   // 1-indexed cell 4
+  EXPECT_FLOAT_EQ(max_cell.state, 4.0f);  // 1-indexed cell 4
   EXPECT_NEAR(avg.state, 3.325f, 0.001f);
   EXPECT_NEAR(min_v.state, 3.322f, 0.001f);
-  EXPECT_FLOAT_EQ(min_cell.state, 1.0f);   // 1-indexed cell 1
+  EXPECT_FLOAT_EQ(min_cell.state, 1.0f);  // 1-indexed cell 1
   EXPECT_NEAR(delta.state, 0.007f, 0.001f);
 }
 

--- a/tests/components/jbd_bms_up_pack/pack_status_test.cpp
+++ b/tests/components/jbd_bms_up_pack/pack_status_test.cpp
@@ -5,17 +5,18 @@
 namespace esphome::jbd_bms_up_pack::testing {
 
 using esphome::jbd_bms_up::testing::PACK_STATUS_FRAME;
+using esphome::jbd_bms_up::testing::PACK_STATUS_FRAME_ADDR2;
 using esphome::jbd_bms_up::testing::make_pack_status_charging;
 using esphome::jbd_bms_up::testing::make_pack_status_with_errors;
 
-// ── Voltage and current ───────────────────────────────────────────────────────
+// ── Voltage and current — addr=1 ─────────────────────────────────────────────
 
 TEST(PackStatusTest, TotalVoltage) {
   TestableJbdBmsUpPack pack;
   sensor::Sensor total;
   pack.set_total_voltage_sensor(&total);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(total.state, 52.90f, 0.01f);
+  EXPECT_NEAR(total.state, 53.17f, 0.01f);
 }
 
 TEST(PackStatusTest, CurrentZero) {
@@ -49,7 +50,7 @@ TEST(PackStatusTest, StateOfCharge) {
   sensor::Sensor soc;
   pack.set_state_of_charge_sensor(&soc);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(soc.state, 45.19f, 0.01f);
+  EXPECT_NEAR(soc.state, 60.95f, 0.01f);
 }
 
 TEST(PackStatusTest, Capacity) {
@@ -58,7 +59,7 @@ TEST(PackStatusTest, Capacity) {
   pack.set_capacity_remaining_sensor(&cap_rem);
   pack.set_nominal_capacity_sensor(&nominal);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(cap_rem.state, 45.19f, 0.01f);
+  EXPECT_NEAR(cap_rem.state, 60.95f, 0.01f);
   EXPECT_NEAR(nominal.state, 100.00f, 0.01f);
 }
 
@@ -70,14 +71,14 @@ TEST(PackStatusTest, ChargingCycles) {
   EXPECT_FLOAT_EQ(cycles.state, 12.0f);
 }
 
-// ── Temperatures (UP-only sensors) ───────────────────────────────────────────
+// ── Temperatures ─────────────────────────────────────────────────────────────
 
 TEST(PackStatusTest, MosfetTemperature) {
   TestableJbdBmsUpPack pack;
   sensor::Sensor temp;
   pack.set_mosfet_temperature_sensor(&temp);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(temp.state, 25.6f, 0.1f);
+  EXPECT_NEAR(temp.state, 21.0f, 0.1f);
 }
 
 TEST(PackStatusTest, AmbientTemperature) {
@@ -85,7 +86,7 @@ TEST(PackStatusTest, AmbientTemperature) {
   sensor::Sensor temp;
   pack.set_ambient_temperature_sensor(&temp);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(temp.state, 27.4f, 0.1f);
+  EXPECT_NEAR(temp.state, 22.6f, 0.1f);
 }
 
 TEST(PackStatusTest, CellTemperatures) {
@@ -94,13 +95,13 @@ TEST(PackStatusTest, CellTemperatures) {
   for (int i = 0; i < 4; i++)
     pack.set_temperature_sensor(i, &t[i]);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(t[0].state, 26.0f, 0.1f);
-  EXPECT_NEAR(t[1].state, 25.4f, 0.1f);
-  EXPECT_NEAR(t[2].state, 26.2f, 0.1f);
-  EXPECT_NEAR(t[3].state, 26.4f, 0.1f);
+  EXPECT_NEAR(t[0].state, 20.9f, 0.1f);
+  EXPECT_NEAR(t[1].state, 20.4f, 0.1f);
+  EXPECT_NEAR(t[2].state, 21.0f, 0.1f);
+  EXPECT_NEAR(t[3].state, 21.2f, 0.1f);
 }
 
-// ── State of health (UP-only) ─────────────────────────────────────────────────
+// ── State of health ───────────────────────────────────────────────────────────
 
 TEST(PackStatusTest, StateOfHealth) {
   TestableJbdBmsUpPack pack;
@@ -150,13 +151,12 @@ TEST(PackStatusTest, ErrorsBitmaskDecoded) {
   pack.set_errors_bitmask_sensor(&errors);
   pack.set_errors_text_sensor(&errors_text);
   pack.on_pack_status_(make_pack_status_with_errors());
-  // errors_bitmask = 0x00010001: bit0=cell_overvoltage, bit16=eep_fault
   EXPECT_FLOAT_EQ(errors.state, 0x00010001);
   EXPECT_NE(errors_text.state.find("Cell overvoltage"), std::string::npos);
   EXPECT_NE(errors_text.state.find("EEP fault"), std::string::npos);
 }
 
-// ── MOSFET status and binary sensors ─────────────────────────────────────────
+// ── MOSFET status ─────────────────────────────────────────────────────────────
 
 TEST(PackStatusTest, MosfetStatusBothEnabled) {
   TestableJbdBmsUpPack pack;
@@ -167,7 +167,7 @@ TEST(PackStatusTest, MosfetStatusBothEnabled) {
   pack.set_heat_binary_sensor(&heat);
   pack.set_fan_binary_sensor(&fan);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  // MOSFET status 0x0003: bit0=DSG=1, bit1=CHG=1, bit2=precharge=0
+  // mos=0x0003: bit0=DSG=1, bit1=CHG=1, bit2..4=0
   EXPECT_TRUE(discharging.state);
   EXPECT_TRUE(charging.state);
   EXPECT_FALSE(precharging.state);
@@ -187,15 +187,13 @@ TEST(PackStatusTest, CellVoltageStats) {
   pack.set_average_cell_voltage_sensor(&avg);
   pack.set_delta_cell_voltage_sensor(&delta);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_NEAR(max_v.state, 3.307f, 0.001f);
-  EXPECT_FLOAT_EQ(max_cell.state, 1.0f);
-  EXPECT_NEAR(avg.state, 3.306f, 0.001f);
-  EXPECT_NEAR(min_v.state, 3.306f, 0.001f);
-  EXPECT_FLOAT_EQ(min_cell.state, 2.0f);
-  EXPECT_NEAR(delta.state, 0.001f, 0.001f);
+  EXPECT_NEAR(max_v.state, 3.331f, 0.001f);
+  EXPECT_FLOAT_EQ(max_cell.state, 3.0f);   // 1-indexed cell 3
+  EXPECT_NEAR(avg.state, 3.323f, 0.001f);
+  EXPECT_NEAR(min_v.state, 3.317f, 0.001f);
+  EXPECT_FLOAT_EQ(min_cell.state, 8.0f);   // 1-indexed cell 8
+  EXPECT_NEAR(delta.state, 0.014f, 0.001f);
 }
-
-// ── Individual cell voltages ──────────────────────────────────────────────────
 
 TEST(PackStatusTest, BatteryStrings) {
   TestableJbdBmsUpPack pack;
@@ -211,17 +209,17 @@ TEST(PackStatusTest, CellVoltages) {
   for (int i = 0; i < 16; i++)
     pack.set_cell_voltage_sensor(i, &cells[i]);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  // All cells between 3.306 and 3.308 V (3.308 accounts for float precision of 0.001 scaling)
+  // Spot-check known values from capture
+  EXPECT_NEAR(cells[0].state, 3.326f, 0.001f);   // cell[0]:  0x0CFE
+  EXPECT_NEAR(cells[2].state, 3.331f, 0.001f);   // cell[2]:  0x0D03 ← max
+  EXPECT_NEAR(cells[7].state, 3.317f, 0.001f);   // cell[7]:  0x0CF5 ← min
+  EXPECT_NEAR(cells[6].state, 3.328f, 0.001f);   // cell[6]:  0x0D00
+  EXPECT_NEAR(cells[15].state, 3.322f, 0.001f);  // cell[15]: 0x0CFA
+  // All cells within measured range [3.317 V, 3.331 V]
   for (int i = 0; i < 16; i++) {
-    EXPECT_GE(cells[i].state, 3.306f) << "cell " << i;
-    EXPECT_LT(cells[i].state, 3.308f) << "cell " << i;
+    EXPECT_GE(cells[i].state, 3.316f) << "cell " << i;
+    EXPECT_LE(cells[i].state, 3.332f) << "cell " << i;
   }
-  // Spot-check known values (0-indexed cells)
-  EXPECT_NEAR(cells[0].state, 3.307f, 0.001f);   // cell[0]:  0x0CEB
-  EXPECT_NEAR(cells[2].state, 3.306f, 0.001f);   // cell[2]:  0x0CEA
-  EXPECT_NEAR(cells[8].state, 3.306f, 0.001f);   // cell[8]:  0x0CEA
-  EXPECT_NEAR(cells[13].state, 3.306f, 0.001f);  // cell[13]: 0x0CEA
-  EXPECT_NEAR(cells[15].state, 3.307f, 0.001f);  // cell[15]: 0x0CEB
 }
 
 // ── Device model ──────────────────────────────────────────────────────────────
@@ -231,14 +229,71 @@ TEST(PackStatusTest, DeviceModel) {
   text_sensor::TextSensor model;
   pack.set_device_model_text_sensor(&model);
   pack.on_pack_status_(PACK_STATUS_FRAME);
-  EXPECT_EQ(model.state.substr(0, 10), "JBD4810000");
+  EXPECT_EQ(model.state.substr(0, 11), "JBD48100000");
 }
 
-// ── Null sensors do not crash ─────────────────────────────────────────────────
+// ── Second device (addr=2) ────────────────────────────────────────────────────
+
+TEST(PackStatusTest, Addr2TotalVoltage) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor total;
+  pack.set_total_voltage_sensor(&total);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(total.state, 53.21f, 0.01f);
+}
+
+TEST(PackStatusTest, Addr2StateOfCharge) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor soc;
+  pack.set_state_of_charge_sensor(&soc);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(soc.state, 73.00f, 0.01f);
+}
+
+TEST(PackStatusTest, Addr2ChargingCycles) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor cycles;
+  pack.set_charging_cycles_sensor(&cycles);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_FLOAT_EQ(cycles.state, 2.0f);
+}
+
+TEST(PackStatusTest, Addr2CellVoltageStats) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor min_v, max_v, min_cell, max_cell, avg, delta;
+  pack.set_min_cell_voltage_sensor(&min_v);
+  pack.set_max_cell_voltage_sensor(&max_v);
+  pack.set_min_voltage_cell_sensor(&min_cell);
+  pack.set_max_voltage_cell_sensor(&max_cell);
+  pack.set_average_cell_voltage_sensor(&avg);
+  pack.set_delta_cell_voltage_sensor(&delta);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(max_v.state, 3.329f, 0.001f);
+  EXPECT_FLOAT_EQ(max_cell.state, 4.0f);   // 1-indexed cell 4
+  EXPECT_NEAR(avg.state, 3.325f, 0.001f);
+  EXPECT_NEAR(min_v.state, 3.322f, 0.001f);
+  EXPECT_FLOAT_EQ(min_cell.state, 1.0f);   // 1-indexed cell 1
+  EXPECT_NEAR(delta.state, 0.007f, 0.001f);
+}
+
+TEST(PackStatusTest, Addr2CellTemperatures) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor t[4];
+  for (int i = 0; i < 4; i++)
+    pack.set_temperature_sensor(i, &t[i]);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(t[0].state, 21.4f, 0.1f);
+  EXPECT_NEAR(t[1].state, 21.3f, 0.1f);
+  EXPECT_NEAR(t[2].state, 22.0f, 0.1f);
+  EXPECT_NEAR(t[3].state, 21.8f, 0.1f);
+}
+
+// ── Robustness ────────────────────────────────────────────────────────────────
 
 TEST(PackStatusTest, NullSensorsDoNotCrash) {
   TestableJbdBmsUpPack pack;
   pack.on_pack_status_(PACK_STATUS_FRAME);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
   pack.on_pack_status_(make_pack_status_charging());
   pack.on_pack_status_(make_pack_status_with_errors());
 }
@@ -247,9 +302,7 @@ TEST(PackStatusTest, ShortFrameDoesNotCrash) {
   TestableJbdBmsUpPack pack;
   sensor::Sensor total;
   pack.set_total_voltage_sensor(&total);
-  // Frame too short: should be rejected gracefully
   pack.on_pack_status_({0x14, 0x8f, 0x00, 0x00});
-  // sensor stays at default (0), no crash
 }
 
 // ── on_jbd_bms_up_data dispatch ───────────────────────────────────────────────
@@ -258,9 +311,16 @@ TEST(PackStatusTest, DispatchPackStatus) {
   TestableJbdBmsUpPack pack;
   sensor::Sensor total;
   pack.set_total_voltage_sensor(&total);
-  // 0x78 + 0x1000 → pack status
   pack.on_jbd_bms_up_data(0x78, 0x1000, PACK_STATUS_FRAME);
-  EXPECT_NEAR(total.state, 52.90f, 0.01f);
+  EXPECT_NEAR(total.state, 53.17f, 0.01f);
+}
+
+TEST(PackStatusTest, DispatchPackStatusAddr2) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor total;
+  pack.set_total_voltage_sensor(&total);
+  pack.on_jbd_bms_up_data(0x78, 0x1000, PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(total.state, 53.21f, 0.01f);
 }
 
 TEST(PackStatusTest, UnknownFunctionDoesNotCrash) {
@@ -268,28 +328,5 @@ TEST(PackStatusTest, UnknownFunctionDoesNotCrash) {
   pack.on_jbd_bms_up_data(0x78, 0x1C00, {0x00, 0x01, 0x02});
   pack.on_jbd_bms_up_data(0x45, 0x0000, {0x00, 0x01, 0x02});
 }
-
-// ── @TODO: missing response decode tests ─────────────────────────────────────
-//
-// @TODO Pack Parameters decode (0x1C00 response, 136 bytes):
-//   Contains: balance_voltage, charge/discharge thresholds, over/under voltage
-//   limits, temperature thresholds, BMS code string, firmware date.
-//   Needs: on_pack_parameters_() + corresponding sensor entities.
-//
-// @TODO Alternate Pack Status decode (FC=0x45 response, 124 bytes):
-//   Contains: per-cell voltages, temperatures, capacity percentages, status.
-//   Different frame layout from 0x1000 response.
-//   Needs: on_alt_pack_status_() handler + FC=0x45 dispatch in on_jbd_bms_up_data.
-//
-// @TODO MOS status with precharging/heat/fan bits active:
-//   Synthetic frame with MOSFET status 0x001C (bits 2,3,4 set).
-//   Verifies precharging=true, heat=true, fan=true.
-//
-// @TODO Discharging current (negative current):
-//   Synthetic frame with current = 295000 → (295000-300000)*0.01 = -50.00 A.
-//   Verifies: current=-50A, discharging_power>0, charging_power=0.
-//
-// @TODO Protect bitmask with all 27 flags set:
-//   Verifies bitmask_to_string_ covers all PROTECT[] entries.
 
 }  // namespace esphome::jbd_bms_up_pack::testing


### PR DESCRIPTION
## Summary

- Replaces all hand-crafted test fixtures in `jbd_bms_up` and `jbd_bms_up_pack` with byte-exact frames from real hardware captures (`docs/pdus/JBD-UP16S020-two-devices.txt`)
- Adds `PACK_STATUS_RESPONSE_ADDR2` (addr=2, 160B) alongside the existing addr=1 frame (168B) — both verified byte-for-byte against the traffic recording
- Adds `MultiDeviceAddressFiltering` and related tests that prove the bus only dispatches each frame to the matching device address, covering the multi-device use case from #230
- Exposes `feed_frame()` + `rx_buffer_` on `TestableJbdBmsUp` to correctly mirror `parse_read_` buffer-clear semantics in multi-frame test sequences

**58 tests pass** (was 57 before; 10 new test cases added).

## Key captured values

| | addr=1 | addr=2 |
|---|---|---|
| Frame size | 168B (dlen=158) | 160B (dlen=150) |
| Total voltage | 53.17 V | 53.21 V |
| SOC | 60.95 % | 73.00 % |
| Cycles | 12 | 2 |
| Mosfet temp | 21.0 °C | 21.4 °C |
| Max cell | 3.331 V (cell 3) | 3.329 V (cell 4) |
| Min cell | 3.317 V (cell 8) | 3.322 V (cell 1) |

## Test plan

- [x] `script/cpp_unit_test.py jbd_bms_up jbd_bms_up_pack` — 58/58 pass
- [x] Python schema tests — 19/19 pass