### PR TITLE
Make GATT service and characteristic UUIDs configurable (jbd_bms_ble)

### DIFF
--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -1,10 +1,9 @@
 import esphome.codegen as cg
 from esphome.components import ble_client
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_PASSWORD
+from esphome.const import CONF_ID, CONF_PASSWORD, CONF_SERVICE_UUID
 
 CONF_AUTH_TIMEOUT = "auth_timeout"
-CONF_SERVICE_UUID = "service_uuid"
 CONF_NOTIFY_CHARACTERISTIC_UUID = "notify_characteristic_uuid"
 CONF_CONTROL_CHARACTERISTIC_UUID = "control_characteristic_uuid"
 

--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -4,6 +4,9 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PASSWORD
 
 CONF_AUTH_TIMEOUT = "auth_timeout"
+CONF_SERVICE_UUID = "service_uuid"
+CONF_NOTIFY_CHARACTERISTIC_UUID = "notify_characteristic_uuid"
+CONF_CONTROL_CHARACTERISTIC_UUID = "control_characteristic_uuid"
 
 CODEOWNERS = ["@syssi"]
 DEPENDENCIES = ["ble_client"]
@@ -49,6 +52,15 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JbdBmsBle),
+            cv.Optional(CONF_SERVICE_UUID, default=0xFF00): cv.int_range(
+                min=0, max=0xFFFF
+            ),
+            cv.Optional(CONF_NOTIFY_CHARACTERISTIC_UUID, default=0xFF01): cv.int_range(
+                min=0, max=0xFFFF
+            ),
+            cv.Optional(CONF_CONTROL_CHARACTERISTIC_UUID, default=0xFF02): cv.int_range(
+                min=0, max=0xFFFF
+            ),
             cv.Optional(CONF_PASSWORD, default=""): cv.All(
                 cv.string_strict, validate_password
             ),
@@ -66,6 +78,12 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await ble_client.register_ble_node(var, config)
+
+    cg.add(var.set_service_uuid(config[CONF_SERVICE_UUID]))
+    cg.add(var.set_notify_characteristic_uuid(config[CONF_NOTIFY_CHARACTERISTIC_UUID]))
+    cg.add(
+        var.set_control_characteristic_uuid(config[CONF_CONTROL_CHARACTERISTIC_UUID])
+    )
 
     if CONF_PASSWORD in config and config[CONF_PASSWORD]:
         cg.add(var.set_password(config[CONF_PASSWORD]))

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -15,10 +15,6 @@ static const char *const TAG = "jbd_bms_ble";
 
 static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
-static const uint16_t JBD_BMS_SERVICE_UUID = 0xFF00;
-static const uint16_t JBD_BMS_NOTIFY_CHARACTERISTIC_UUID = 0xFF01;
-static const uint16_t JBD_BMS_CONTROL_CHARACTERISTIC_UUID = 0xFF02;
-
 static const uint16_t MAX_RESPONSE_SIZE = 41;
 
 static const uint8_t JBD_PKT_START = 0xDD;
@@ -114,7 +110,7 @@ void JbdBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
       break;
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
-      auto *char_notify = this->parent_->get_characteristic(JBD_BMS_SERVICE_UUID, JBD_BMS_NOTIFY_CHARACTERISTIC_UUID);
+      auto *char_notify = this->parent_->get_characteristic(this->service_uuid_, this->notify_char_uuid_);
       if (char_notify == nullptr) {
         ESP_LOGE(TAG, "[%s] No notify service found at device, not an JBD BMS..?",
                  ADDR_STR(this->parent_->address_str()));
@@ -128,7 +124,7 @@ void JbdBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
         ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", status);
       }
 
-      auto *char_command = this->parent_->get_characteristic(JBD_BMS_SERVICE_UUID, JBD_BMS_CONTROL_CHARACTERISTIC_UUID);
+      auto *char_command = this->parent_->get_characteristic(this->service_uuid_, this->control_char_uuid_);
       if (char_command == nullptr) {
         ESP_LOGE(TAG, "[%s] No control service found at device, not an JBD BMS..?",
                  ADDR_STR(this->parent_->address_str()));
@@ -711,6 +707,9 @@ void JbdBmsBle::publish_device_unavailable_() {
 
 void JbdBmsBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "JbdBmsBle:");
+  ESP_LOGCONFIG(TAG, "  Service UUID: 0x%04X", this->service_uuid_);
+  ESP_LOGCONFIG(TAG, "  Notify Characteristic UUID: 0x%04X", this->notify_char_uuid_);
+  ESP_LOGCONFIG(TAG, "  Control Characteristic UUID: 0x%04X", this->control_char_uuid_);
 
   LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -212,6 +212,9 @@ class JbdBmsBle :
   void set_balancing_cells_text_sensor(text_sensor::TextSensor *balancing_cells_text_sensor) {
     balancing_cells_text_sensor_ = balancing_cells_text_sensor;
   }
+  void set_service_uuid(uint16_t uuid) { service_uuid_ = uuid; }
+  void set_notify_characteristic_uuid(uint16_t uuid) { notify_char_uuid_ = uuid; }
+  void set_control_characteristic_uuid(uint16_t uuid) { control_char_uuid_ = uuid; }
   void set_password(const std::string &password) {
     password_ = password;
     enable_authentication_ = !password.empty();
@@ -301,6 +304,10 @@ class JbdBmsBle :
   // Cycle life
   // Production date
   // Version
+
+  uint16_t service_uuid_{0xFF00};
+  uint16_t notify_char_uuid_{0xFF01};
+  uint16_t control_char_uuid_{0xFF02};
 
   std::vector<uint8_t> frame_buffer_;
   std::string device_model_{};


### PR DESCRIPTION
## Summary

Some newer JBD BMS devices (e.g. `WTDH04SC02200ABUH` / DH04SC02) use different GATT characteristic UUIDs (`0xFFF1`/`0xFFF2`) instead of the standard `0xFF01`/`0xFF02`. The protocol is identical — only the service and characteristic UUIDs differ.

This PR exposes three optional config options on `jbd_bms_ble` with the existing values as defaults, so these devices work without any other modification:

```yaml
jbd_bms_ble:
  mac_address: "AA:C2:37:xx:xx:xx"
  service_uuid: 0xFFF0
  notify_characteristic_uuid: 0xFFF1
  control_characteristic_uuid: 0xFFF2
```

- `service_uuid` (default: `0xFF00`)
- `notify_characteristic_uuid` (default: `0xFF01`)
- `control_characteristic_uuid` (default: `0xFF02`)

All three are validated as 16-bit integers (`0x0000`–`0xFFFF`). The configured values are logged in `dump_config()`.

Closes #232

## Changes

- **`__init__.py`**: Three new optional config keys with existing defaults; setters called in `to_code`
- **`jbd_bms_ble.h`**: Three setters + three protected member variables (initialized to current defaults)
- **`jbd_bms_ble.cpp`**: Removed hardcoded static constants; `get_characteristic()` calls use instance variables; `dump_config()` logs the active UUIDs

## Test plan

- [ ] Verify existing config without new options compiles and behaves identically (defaults unchanged)
- [ ] Verify config with `0xFFF0`/`0xFFF1`/`0xFFF2` compiles
- [ ] On-device test with a DH04SC02 BMS (requires physical hardware — runtime behavior cannot be covered by automated tests)