### PR TITLE
[jbd_bms] Add YAML component tests covering all entities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -459,6 +459,13 @@ jobs:
             esphome -s external_components_source ../components config $YAML
           done
 
+      - name: Validate component test configurations
+        run: |
+          . venv/bin/activate
+          for YAML in esphome/tests/components/jbd_bms/test.*.yaml; do
+            esphome config $YAML
+          done
+
   esphome-compile:
     name: Build example configurations
     runs-on: ubuntu-24.04

--- a/tests/components/jbd_bms/common.h
+++ b/tests/components/jbd_bms/common.h
@@ -2,8 +2,11 @@
 #include <array>
 #include <cstdint>
 #include <vector>
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/jbd_bms/jbd_bms.h"
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 
 namespace esphome::jbd_bms::testing {
 
@@ -26,6 +29,101 @@ class TestableJbdBms : public JbdBms {
 class TestableSwitch : public switch_::Switch {
  public:
   void write_state(bool state) override { this->publish_state(state); }
+};
+
+// Pre-wired fixture with all entities attached to a single TestableJbdBms.
+// Stack-allocate one per test that needs parsed output.
+struct JbdBmsTestBench {
+  TestableJbdBms bms;
+
+  sensor::Sensor total_voltage, current, power, charging_power, discharging_power;
+  sensor::Sensor state_of_charge, nominal_capacity, charging_cycles, capacity_remaining, battery_cycle_capacity;
+  sensor::Sensor min_cell_voltage, max_cell_voltage, min_voltage_cell, max_voltage_cell;
+  sensor::Sensor delta_cell_voltage, average_cell_voltage;
+  sensor::Sensor operation_status_bitmask, errors_bitmask, balancer_status_bitmask;
+  sensor::Sensor battery_strings, temperature_sensors_count, software_version;
+  sensor::Sensor short_circuit_error_count, charge_overcurrent_error_count, discharge_overcurrent_error_count;
+  sensor::Sensor cell_overvoltage_error_count, cell_undervoltage_error_count;
+  sensor::Sensor charge_overtemperature_error_count, charge_undertemperature_error_count;
+  sensor::Sensor discharge_overtemperature_error_count, discharge_undertemperature_error_count;
+  sensor::Sensor battery_overvoltage_error_count, battery_undervoltage_error_count;
+  sensor::Sensor cells[32];
+  sensor::Sensor temps[6];
+
+  binary_sensor::BinarySensor charging_bs, discharging_bs, balancing_bs, online_status_bs;
+  binary_sensor::BinarySensor cell_overvoltage_protection, cell_undervoltage_protection;
+  binary_sensor::BinarySensor pack_overvoltage_protection, pack_undervoltage_protection;
+  binary_sensor::BinarySensor charge_overtemperature_protection, charge_undertemperature_protection;
+  binary_sensor::BinarySensor discharge_overtemperature_protection, discharge_undertemperature_protection;
+  binary_sensor::BinarySensor charge_overcurrent_protection, discharge_overcurrent_protection;
+  binary_sensor::BinarySensor short_circuit_protection, ic_frontend_error, mosfet_software_lock;
+
+  text_sensor::TextSensor errors_ts, operation_status_ts, device_model_ts, balancing_cells_ts;
+
+  TestableSwitch charging_sw, discharging_sw;
+
+  JbdBmsTestBench() {
+    bms.set_total_voltage_sensor(&total_voltage);
+    bms.set_current_sensor(&current);
+    bms.set_power_sensor(&power);
+    bms.set_charging_power_sensor(&charging_power);
+    bms.set_discharging_power_sensor(&discharging_power);
+    bms.set_state_of_charge_sensor(&state_of_charge);
+    bms.set_nominal_capacity_sensor(&nominal_capacity);
+    bms.set_charging_cycles_sensor(&charging_cycles);
+    bms.set_capacity_remaining_sensor(&capacity_remaining);
+    bms.set_battery_cycle_capacity_sensor(&battery_cycle_capacity);
+    bms.set_min_cell_voltage_sensor(&min_cell_voltage);
+    bms.set_max_cell_voltage_sensor(&max_cell_voltage);
+    bms.set_min_voltage_cell_sensor(&min_voltage_cell);
+    bms.set_max_voltage_cell_sensor(&max_voltage_cell);
+    bms.set_delta_cell_voltage_sensor(&delta_cell_voltage);
+    bms.set_average_cell_voltage_sensor(&average_cell_voltage);
+    bms.set_operation_status_bitmask_sensor(&operation_status_bitmask);
+    bms.set_errors_bitmask_sensor(&errors_bitmask);
+    bms.set_balancer_status_bitmask_sensor(&balancer_status_bitmask);
+    bms.set_battery_strings_sensor(&battery_strings);
+    bms.set_temperature_sensors_sensor(&temperature_sensors_count);
+    bms.set_software_version_sensor(&software_version);
+    bms.set_short_circuit_error_count_sensor(&short_circuit_error_count);
+    bms.set_charge_overcurrent_error_count_sensor(&charge_overcurrent_error_count);
+    bms.set_discharge_overcurrent_error_count_sensor(&discharge_overcurrent_error_count);
+    bms.set_cell_overvoltage_error_count_sensor(&cell_overvoltage_error_count);
+    bms.set_cell_undervoltage_error_count_sensor(&cell_undervoltage_error_count);
+    bms.set_charge_overtemperature_error_count_sensor(&charge_overtemperature_error_count);
+    bms.set_charge_undertemperature_error_count_sensor(&charge_undertemperature_error_count);
+    bms.set_discharge_overtemperature_error_count_sensor(&discharge_overtemperature_error_count);
+    bms.set_discharge_undertemperature_error_count_sensor(&discharge_undertemperature_error_count);
+    bms.set_battery_overvoltage_error_count_sensor(&battery_overvoltage_error_count);
+    bms.set_battery_undervoltage_error_count_sensor(&battery_undervoltage_error_count);
+    for (int i = 0; i < 32; i++)
+      bms.set_cell_voltage_sensor(i, &cells[i]);
+    for (int i = 0; i < 6; i++)
+      bms.set_temperature_sensor(i, &temps[i]);
+    bms.set_charging_binary_sensor(&charging_bs);
+    bms.set_discharging_binary_sensor(&discharging_bs);
+    bms.set_balancing_binary_sensor(&balancing_bs);
+    bms.set_online_status_binary_sensor(&online_status_bs);
+    bms.set_cell_overvoltage_protection_binary_sensor(&cell_overvoltage_protection);
+    bms.set_cell_undervoltage_protection_binary_sensor(&cell_undervoltage_protection);
+    bms.set_pack_overvoltage_protection_binary_sensor(&pack_overvoltage_protection);
+    bms.set_pack_undervoltage_protection_binary_sensor(&pack_undervoltage_protection);
+    bms.set_charge_overtemperature_protection_binary_sensor(&charge_overtemperature_protection);
+    bms.set_charge_undertemperature_protection_binary_sensor(&charge_undertemperature_protection);
+    bms.set_discharge_overtemperature_protection_binary_sensor(&discharge_overtemperature_protection);
+    bms.set_discharge_undertemperature_protection_binary_sensor(&discharge_undertemperature_protection);
+    bms.set_charge_overcurrent_protection_binary_sensor(&charge_overcurrent_protection);
+    bms.set_discharge_overcurrent_protection_binary_sensor(&discharge_overcurrent_protection);
+    bms.set_short_circuit_protection_binary_sensor(&short_circuit_protection);
+    bms.set_ic_frontend_error_binary_sensor(&ic_frontend_error);
+    bms.set_mosfet_software_lock_binary_sensor(&mosfet_software_lock);
+    bms.set_errors_text_sensor(&errors_ts);
+    bms.set_operation_status_text_sensor(&operation_status_ts);
+    bms.set_device_model_text_sensor(&device_model_ts);
+    bms.set_balancing_cells_text_sensor(&balancing_cells_ts);
+    bms.set_charging_switch(&charging_sw);
+    bms.set_discharging_switch(&discharging_sw);
+  }
 };
 
 }  // namespace esphome::jbd_bms::testing

--- a/tests/components/jbd_bms/common.yaml
+++ b/tests/components/jbd_bms/common.yaml
@@ -1,0 +1,220 @@
+jbd_bms:
+  id: test_bms
+  uart_id: uart_bus
+  update_interval: 5s
+
+sensor:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    total_voltage:
+      name: Total Voltage
+    current:
+      name: Current
+    power:
+      name: Power
+    charging_power:
+      name: Charging Power
+    discharging_power:
+      name: Discharging Power
+    state_of_charge:
+      name: State of Charge
+    nominal_capacity:
+      name: Nominal Capacity
+    charging_cycles:
+      name: Charging Cycles
+    capacity_remaining:
+      name: Capacity Remaining
+    battery_cycle_capacity:
+      name: Battery Cycle Capacity
+    min_cell_voltage:
+      name: Min Cell Voltage
+    max_cell_voltage:
+      name: Max Cell Voltage
+    min_voltage_cell:
+      name: Min Voltage Cell
+    max_voltage_cell:
+      name: Max Voltage Cell
+    delta_cell_voltage:
+      name: Delta Cell Voltage
+    average_cell_voltage:
+      name: Average Cell Voltage
+    operation_status_bitmask:
+      name: Operation Status Bitmask
+    errors_bitmask:
+      name: Errors Bitmask
+    balancer_status_bitmask:
+      name: Balancer Status Bitmask
+    battery_strings:
+      name: Battery Strings
+    software_version:
+      name: Software Version
+    short_circuit_error_count:
+      name: Short Circuit Error Count
+    charge_overcurrent_error_count:
+      name: Charge Overcurrent Error Count
+    discharge_overcurrent_error_count:
+      name: Discharge Overcurrent Error Count
+    cell_overvoltage_error_count:
+      name: Cell Overvoltage Error Count
+    cell_undervoltage_error_count:
+      name: Cell Undervoltage Error Count
+    charge_overtemperature_error_count:
+      name: Charge Overtemperature Error Count
+    charge_undertemperature_error_count:
+      name: Charge Undertemperature Error Count
+    discharge_overtemperature_error_count:
+      name: Discharge Overtemperature Error Count
+    discharge_undertemperature_error_count:
+      name: Discharge Undertemperature Error Count
+    battery_overvoltage_error_count:
+      name: Battery Overvoltage Error Count
+    battery_undervoltage_error_count:
+      name: Battery Undervoltage Error Count
+    cell_voltage_1:
+      name: Cell Voltage 1
+    cell_voltage_2:
+      name: Cell Voltage 2
+    cell_voltage_3:
+      name: Cell Voltage 3
+    cell_voltage_4:
+      name: Cell Voltage 4
+    cell_voltage_5:
+      name: Cell Voltage 5
+    cell_voltage_6:
+      name: Cell Voltage 6
+    cell_voltage_7:
+      name: Cell Voltage 7
+    cell_voltage_8:
+      name: Cell Voltage 8
+    cell_voltage_9:
+      name: Cell Voltage 9
+    cell_voltage_10:
+      name: Cell Voltage 10
+    cell_voltage_11:
+      name: Cell Voltage 11
+    cell_voltage_12:
+      name: Cell Voltage 12
+    cell_voltage_13:
+      name: Cell Voltage 13
+    cell_voltage_14:
+      name: Cell Voltage 14
+    cell_voltage_15:
+      name: Cell Voltage 15
+    cell_voltage_16:
+      name: Cell Voltage 16
+    cell_voltage_17:
+      name: Cell Voltage 17
+    cell_voltage_18:
+      name: Cell Voltage 18
+    cell_voltage_19:
+      name: Cell Voltage 19
+    cell_voltage_20:
+      name: Cell Voltage 20
+    cell_voltage_21:
+      name: Cell Voltage 21
+    cell_voltage_22:
+      name: Cell Voltage 22
+    cell_voltage_23:
+      name: Cell Voltage 23
+    cell_voltage_24:
+      name: Cell Voltage 24
+    cell_voltage_25:
+      name: Cell Voltage 25
+    cell_voltage_26:
+      name: Cell Voltage 26
+    cell_voltage_27:
+      name: Cell Voltage 27
+    cell_voltage_28:
+      name: Cell Voltage 28
+    cell_voltage_29:
+      name: Cell Voltage 29
+    cell_voltage_30:
+      name: Cell Voltage 30
+    cell_voltage_31:
+      name: Cell Voltage 31
+    cell_voltage_32:
+      name: Cell Voltage 32
+    temperature_1:
+      name: Temperature 1
+    temperature_2:
+      name: Temperature 2
+    temperature_3:
+      name: Temperature 3
+    temperature_4:
+      name: Temperature 4
+    temperature_5:
+      name: Temperature 5
+    temperature_6:
+      name: Temperature 6
+
+binary_sensor:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    charging:
+      name: Charging
+    discharging:
+      name: Discharging
+    balancing:
+      name: Balancing
+    online_status:
+      name: Online Status
+    cell_overvoltage_protection:
+      name: Cell Overvoltage Protection
+    cell_undervoltage_protection:
+      name: Cell Undervoltage Protection
+    pack_overvoltage_protection:
+      name: Pack Overvoltage Protection
+    pack_undervoltage_protection:
+      name: Pack Undervoltage Protection
+    charge_overtemperature_protection:
+      name: Charge Overtemperature Protection
+    charge_undertemperature_protection:
+      name: Charge Undertemperature Protection
+    discharge_overtemperature_protection:
+      name: Discharge Overtemperature Protection
+    discharge_undertemperature_protection:
+      name: Discharge Undertemperature Protection
+    charge_overcurrent_protection:
+      name: Charge Overcurrent Protection
+    discharge_overcurrent_protection:
+      name: Discharge Overcurrent Protection
+    short_circuit_protection:
+      name: Short Circuit Protection
+    ic_frontend_error:
+      name: IC Frontend Error
+    mosfet_software_lock:
+      name: MOSFET Software Lock
+
+text_sensor:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    errors:
+      name: Errors
+    operation_status:
+      name: Operation Status
+    device_model:
+      name: Device Model
+    balancing_cells:
+      name: Balancing Cells
+
+switch:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    charging:
+      name: Charging Switch
+    discharging:
+      name: Discharging Switch
+
+button:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    retrieve_hardware_version:
+      name: Retrieve Hardware Version
+    retrieve_error_counts:
+      name: Retrieve Error Counts
+    force_soc_reset:
+      name: Force SOC Reset
+    automatic_balancing:
+      name: Automatic Balancing
+    clear_alarm:
+      name: Clear Alarm

--- a/tests/components/jbd_bms/common.yaml
+++ b/tests/components/jbd_bms/common.yaml
@@ -70,8 +70,8 @@ sensor:
       name: Battery Overvoltage Error Count
     battery_undervoltage_error_count:
       name: Battery Undervoltage Error Count
-    this_sensor_does_not_exist:
-      name: Intentional Error To Prove CI Reads This File
+    battery_cycle_capacity:
+      name: Battery Cycle Capacity
     cell_voltage_1:
       name: Cell Voltage 1
     cell_voltage_2:

--- a/tests/components/jbd_bms/common.yaml
+++ b/tests/components/jbd_bms/common.yaml
@@ -70,6 +70,8 @@ sensor:
       name: Battery Overvoltage Error Count
     battery_undervoltage_error_count:
       name: Battery Undervoltage Error Count
+    this_sensor_does_not_exist:
+      name: Intentional Error To Prove CI Reads This File
     cell_voltage_1:
       name: Cell Voltage 1
     cell_voltage_2:

--- a/tests/components/jbd_bms/jbd_bms_test.cpp
+++ b/tests/components/jbd_bms/jbd_bms_test.cpp
@@ -7,404 +7,242 @@ namespace esphome::jbd_bms::testing {
 // ── Total voltage ─────────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, TotalVoltage) {
-  TestableJbdBms bms;
-  sensor::Sensor total;
-  bms.set_total_voltage_sensor(&total);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_NEAR(total.state, 15.60f, 0.01f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_NEAR(b.total_voltage.state, 15.60f, 0.01f);
 }
 
 // ── Current and power ─────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, CurrentAndPower) {
-  TestableJbdBms bms;
-  sensor::Sensor current, power, charging_power, discharging_power;
-  bms.set_current_sensor(&current);
-  bms.set_power_sensor(&power);
-  bms.set_charging_power_sensor(&charging_power);
-  bms.set_discharging_power_sensor(&discharging_power);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_NEAR(current.state, 0.0f, 0.001f);
-  EXPECT_NEAR(power.state, 0.0f, 0.01f);
-  EXPECT_NEAR(charging_power.state, 0.0f, 0.01f);
-  EXPECT_NEAR(discharging_power.state, 0.0f, 0.01f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_NEAR(b.current.state, 0.0f, 0.001f);
+  EXPECT_NEAR(b.power.state, 0.0f, 0.01f);
+  EXPECT_NEAR(b.charging_power.state, 0.0f, 0.01f);
+  EXPECT_NEAR(b.discharging_power.state, 0.0f, 0.01f);
 }
 
 // ── Capacity ──────────────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, Capacity) {
-  TestableJbdBms bms;
-  sensor::Sensor cap_rem, nominal, cycles;
-  bms.set_capacity_remaining_sensor(&cap_rem);
-  bms.set_nominal_capacity_sensor(&nominal);
-  bms.set_charging_cycles_sensor(&cycles);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_NEAR(cap_rem.state, 4.98f, 0.01f);
-  EXPECT_NEAR(nominal.state, 5.00f, 0.01f);
-  EXPECT_FLOAT_EQ(cycles.state, 0.0f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_NEAR(b.capacity_remaining.state, 4.98f, 0.01f);
+  EXPECT_NEAR(b.nominal_capacity.state, 5.00f, 0.01f);
+  EXPECT_FLOAT_EQ(b.charging_cycles.state, 0.0f);
 }
 
 // ── State of charge ───────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, StateOfCharge) {
-  TestableJbdBms bms;
-  sensor::Sensor soc;
-  bms.set_state_of_charge_sensor(&soc);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_FLOAT_EQ(soc.state, 100.0f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_FLOAT_EQ(b.state_of_charge.state, 100.0f);
 }
 
 // ── Software version ──────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, SoftwareVersion) {
-  TestableJbdBms bms;
-  sensor::Sensor ver;
-  bms.set_software_version_sensor(&ver);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_NEAR(ver.state, 8.0f, 0.01f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_NEAR(b.software_version.state, 8.0f, 0.01f);
 }
 
 // ── Battery strings and temperature sensors ───────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, BatteryStringsAndTempSensors) {
-  TestableJbdBms bms;
-  sensor::Sensor strings, temp_sensors;
-  bms.set_battery_strings_sensor(&strings);
-  bms.set_temperature_sensors_sensor(&temp_sensors);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_FLOAT_EQ(strings.state, 4.0f);
-  EXPECT_FLOAT_EQ(temp_sensors.state, 3.0f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_FLOAT_EQ(b.battery_strings.state, 4.0f);
+  EXPECT_FLOAT_EQ(b.temperature_sensors_count.state, 3.0f);
 }
 
 // ── Temperatures ──────────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, Temperatures) {
-  TestableJbdBms bms;
-  sensor::Sensor t[3];
-  for (int i = 0; i < 3; i++)
-    bms.set_temperature_sensor(i, &t[i]);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_NEAR(t[0].state, 22.4f, 0.05f);
-  EXPECT_NEAR(t[1].state, 22.3f, 0.05f);
-  EXPECT_NEAR(t[2].state, 21.7f, 0.05f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_NEAR(b.temps[0].state, 22.4f, 0.05f);
+  EXPECT_NEAR(b.temps[1].state, 22.3f, 0.05f);
+  EXPECT_NEAR(b.temps[2].state, 21.7f, 0.05f);
 }
 
 // ── Balancer and error bitmasks ───────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, Bitmasks) {
-  TestableJbdBms bms;
-  sensor::Sensor bal_bitmask, err_bitmask, op_bitmask;
-  bms.set_balancer_status_bitmask_sensor(&bal_bitmask);
-  bms.set_errors_bitmask_sensor(&err_bitmask);
-  bms.set_operation_status_bitmask_sensor(&op_bitmask);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_FLOAT_EQ(bal_bitmask.state, 0.0f);
-  EXPECT_FLOAT_EQ(err_bitmask.state, 0.0f);
-  EXPECT_FLOAT_EQ(op_bitmask.state, 3.0f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_FLOAT_EQ(b.balancer_status_bitmask.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.errors_bitmask.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.operation_status_bitmask.state, 3.0f);
 }
 
 // ── Binary sensors and switches ───────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, BinarySensorsAndSwitches) {
-  TestableJbdBms bms;
-  binary_sensor::BinarySensor charging_bs, discharging_bs, balancing_bs;
-  TestableSwitch charging_sw, discharging_sw;
-  bms.set_charging_binary_sensor(&charging_bs);
-  bms.set_discharging_binary_sensor(&discharging_bs);
-  bms.set_balancing_binary_sensor(&balancing_bs);
-  bms.set_charging_switch(&charging_sw);
-  bms.set_discharging_switch(&discharging_sw);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_TRUE(charging_bs.state);
-  EXPECT_TRUE(discharging_bs.state);
-  EXPECT_FALSE(balancing_bs.state);
-  EXPECT_TRUE(charging_sw.state);
-  EXPECT_TRUE(discharging_sw.state);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_TRUE(b.charging_bs.state);
+  EXPECT_TRUE(b.discharging_bs.state);
+  EXPECT_FALSE(b.balancing_bs.state);
+  EXPECT_TRUE(b.charging_sw.state);
+  EXPECT_TRUE(b.discharging_sw.state);
 }
 
 // ── Operation status text ─────────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, OperationStatusText) {
-  TestableJbdBms bms;
-  text_sensor::TextSensor op_status;
-  bms.set_operation_status_text_sensor(&op_status);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_NE(op_status.state.find("Charging"), std::string::npos);
-  EXPECT_NE(op_status.state.find("Discharging"), std::string::npos);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_NE(b.operation_status_ts.state.find("Charging"), std::string::npos);
+  EXPECT_NE(b.operation_status_ts.state.find("Discharging"), std::string::npos);
 }
 
 // ── Errors text (no errors) ───────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, ErrorsTextEmpty) {
-  TestableJbdBms bms;
-  text_sensor::TextSensor errors;
-  bms.set_errors_text_sensor(&errors);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_EQ(errors.state, "");
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_EQ(b.errors_ts.state, "");
 }
 
 // ── Cell voltages ─────────────────────────────────────────────────────────────
 
 TEST(JbdBmsCellInfoTest, CellVoltages) {
-  TestableJbdBms bms;
-  sensor::Sensor cells[4];
-  for (int i = 0; i < 4; i++)
-    bms.set_cell_voltage_sensor(i, &cells[i]);
-
-  bms.on_jbd_bms_data(0x04, CELLINFO_FRAME);
-
-  EXPECT_NEAR(cells[0].state, 3.909f, 0.001f);
-  EXPECT_NEAR(cells[1].state, 3.901f, 0.001f);
-  EXPECT_NEAR(cells[2].state, 3.895f, 0.001f);
-  EXPECT_NEAR(cells[3].state, 3.901f, 0.001f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x04, CELLINFO_FRAME);
+  EXPECT_NEAR(b.cells[0].state, 3.909f, 0.001f);
+  EXPECT_NEAR(b.cells[1].state, 3.901f, 0.001f);
+  EXPECT_NEAR(b.cells[2].state, 3.895f, 0.001f);
+  EXPECT_NEAR(b.cells[3].state, 3.901f, 0.001f);
 }
 
 // ── Cell voltage statistics ───────────────────────────────────────────────────
 
 TEST(JbdBmsCellInfoTest, CellVoltageStats) {
-  TestableJbdBms bms;
-  sensor::Sensor min_v, max_v, min_cell, max_cell, delta, avg;
-  bms.set_min_cell_voltage_sensor(&min_v);
-  bms.set_max_cell_voltage_sensor(&max_v);
-  bms.set_min_voltage_cell_sensor(&min_cell);
-  bms.set_max_voltage_cell_sensor(&max_cell);
-  bms.set_delta_cell_voltage_sensor(&delta);
-  bms.set_average_cell_voltage_sensor(&avg);
-
-  bms.on_jbd_bms_data(0x04, CELLINFO_FRAME);
-
-  EXPECT_NEAR(min_v.state, 3.895f, 0.001f);
-  EXPECT_NEAR(max_v.state, 3.909f, 0.001f);
-  EXPECT_FLOAT_EQ(min_cell.state, 3.0f);
-  EXPECT_FLOAT_EQ(max_cell.state, 1.0f);
-  EXPECT_NEAR(delta.state, 0.014f, 0.001f);
-  EXPECT_NEAR(avg.state, 3.9015f, 0.001f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x04, CELLINFO_FRAME);
+  EXPECT_NEAR(b.min_cell_voltage.state, 3.895f, 0.001f);
+  EXPECT_NEAR(b.max_cell_voltage.state, 3.909f, 0.001f);
+  EXPECT_FLOAT_EQ(b.min_voltage_cell.state, 3.0f);
+  EXPECT_FLOAT_EQ(b.max_voltage_cell.state, 1.0f);
+  EXPECT_NEAR(b.delta_cell_voltage.state, 0.014f, 0.001f);
+  EXPECT_NEAR(b.average_cell_voltage.state, 3.9015f, 0.001f);
 }
 
 // ── Device model ──────────────────────────────────────────────────────────────
 
 TEST(JbdBmsHwVerTest, DeviceModel) {
-  TestableJbdBms bms;
-  text_sensor::TextSensor model;
-  bms.set_device_model_text_sensor(&model);
-
-  bms.on_jbd_bms_data(0x05, HWVER_FRAME);
-
-  EXPECT_EQ(model.state, "JBD-SP04S034-L4S-200A-B-U");
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x05, HWVER_FRAME);
+  EXPECT_EQ(b.device_model_ts.state, "JBD-SP04S034-L4S-200A-B-U");
 }
 
 // ── Error counts ──────────────────────────────────────────────────────────────
 
 TEST(JbdBmsErrorCountsTest, ErrorCounts) {
-  TestableJbdBms bms;
-  sensor::Sensor sc, co, doc, cov, cuv, cot, cut, dot, dut, bov, buv;
-  bms.set_short_circuit_error_count_sensor(&sc);
-  bms.set_charge_overcurrent_error_count_sensor(&co);
-  bms.set_discharge_overcurrent_error_count_sensor(&doc);
-  bms.set_cell_overvoltage_error_count_sensor(&cov);
-  bms.set_cell_undervoltage_error_count_sensor(&cuv);
-  bms.set_charge_overtemperature_error_count_sensor(&cot);
-  bms.set_charge_undertemperature_error_count_sensor(&cut);
-  bms.set_discharge_overtemperature_error_count_sensor(&dot);
-  bms.set_discharge_undertemperature_error_count_sensor(&dut);
-  bms.set_battery_overvoltage_error_count_sensor(&bov);
-  bms.set_battery_undervoltage_error_count_sensor(&buv);
-
-  bms.on_jbd_bms_data(0xAA, ERRCOUNT_FRAME);
-
-  EXPECT_FLOAT_EQ(sc.state, 0.0f);
-  EXPECT_FLOAT_EQ(co.state, 0.0f);
-  EXPECT_FLOAT_EQ(doc.state, 0.0f);
-  EXPECT_FLOAT_EQ(cov.state, 122.0f);
-  EXPECT_FLOAT_EQ(cuv.state, 2.0f);
-  EXPECT_FLOAT_EQ(cot.state, 0.0f);
-  EXPECT_FLOAT_EQ(cut.state, 0.0f);
-  EXPECT_FLOAT_EQ(dot.state, 0.0f);
-  EXPECT_FLOAT_EQ(dut.state, 0.0f);
-  EXPECT_FLOAT_EQ(bov.state, 0.0f);
-  EXPECT_FLOAT_EQ(buv.state, 0.0f);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0xAA, ERRCOUNT_FRAME);
+  EXPECT_FLOAT_EQ(b.short_circuit_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.charge_overcurrent_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.discharge_overcurrent_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.cell_overvoltage_error_count.state, 122.0f);
+  EXPECT_FLOAT_EQ(b.cell_undervoltage_error_count.state, 2.0f);
+  EXPECT_FLOAT_EQ(b.charge_overtemperature_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.charge_undertemperature_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.discharge_overtemperature_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.discharge_undertemperature_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.battery_overvoltage_error_count.state, 0.0f);
+  EXPECT_FLOAT_EQ(b.battery_undervoltage_error_count.state, 0.0f);
 }
 
 // ── Protection binary sensors ─────────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsNoneActive) {
-  TestableJbdBms bms;
-  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
-  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
-  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
-  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
-  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
-  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
-  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
-  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
-  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
-  bms.set_charge_overcurrent_protection_binary_sensor(&co);
-  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
-  bms.set_short_circuit_protection_binary_sensor(&sc);
-  bms.set_ic_frontend_error_binary_sensor(&ic);
-  bms.set_mosfet_software_lock_binary_sensor(&swl);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_FALSE(cov.state);
-  EXPECT_FALSE(cuv.state);
-  EXPECT_FALSE(pov.state);
-  EXPECT_FALSE(puv.state);
-  EXPECT_FALSE(cot.state);
-  EXPECT_FALSE(cut.state);
-  EXPECT_FALSE(dot.state);
-  EXPECT_FALSE(dut.state);
-  EXPECT_FALSE(co.state);
-  EXPECT_FALSE(doc.state);
-  EXPECT_FALSE(sc.state);
-  EXPECT_FALSE(ic.state);
-  EXPECT_FALSE(swl.state);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_FALSE(b.cell_overvoltage_protection.state);
+  EXPECT_FALSE(b.cell_undervoltage_protection.state);
+  EXPECT_FALSE(b.pack_overvoltage_protection.state);
+  EXPECT_FALSE(b.pack_undervoltage_protection.state);
+  EXPECT_FALSE(b.charge_overtemperature_protection.state);
+  EXPECT_FALSE(b.charge_undertemperature_protection.state);
+  EXPECT_FALSE(b.discharge_overtemperature_protection.state);
+  EXPECT_FALSE(b.discharge_undertemperature_protection.state);
+  EXPECT_FALSE(b.charge_overcurrent_protection.state);
+  EXPECT_FALSE(b.discharge_overcurrent_protection.state);
+  EXPECT_FALSE(b.short_circuit_protection.state);
+  EXPECT_FALSE(b.ic_frontend_error.state);
+  EXPECT_FALSE(b.mosfet_software_lock.state);
 }
 
 TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsCellOvervoltage) {
-  TestableJbdBms bms;
-  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
-  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
-  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
-  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
-  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
-  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
-  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
-  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
-  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
-  bms.set_charge_overcurrent_protection_binary_sensor(&co);
-  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
-  bms.set_short_circuit_protection_binary_sensor(&sc);
-  bms.set_ic_frontend_error_binary_sensor(&ic);
-  bms.set_mosfet_software_lock_binary_sensor(&swl);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_CELL_OVERVOLTAGE);
-
-  EXPECT_TRUE(cov.state);
-  EXPECT_FALSE(cuv.state);
-  EXPECT_FALSE(pov.state);
-  EXPECT_FALSE(puv.state);
-  EXPECT_FALSE(cot.state);
-  EXPECT_FALSE(cut.state);
-  EXPECT_FALSE(dot.state);
-  EXPECT_FALSE(dut.state);
-  EXPECT_FALSE(co.state);
-  EXPECT_FALSE(doc.state);
-  EXPECT_FALSE(sc.state);
-  EXPECT_FALSE(ic.state);
-  EXPECT_FALSE(swl.state);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME_CELL_OVERVOLTAGE);
+  EXPECT_TRUE(b.cell_overvoltage_protection.state);
+  EXPECT_FALSE(b.cell_undervoltage_protection.state);
+  EXPECT_FALSE(b.pack_overvoltage_protection.state);
+  EXPECT_FALSE(b.pack_undervoltage_protection.state);
+  EXPECT_FALSE(b.charge_overtemperature_protection.state);
+  EXPECT_FALSE(b.charge_undertemperature_protection.state);
+  EXPECT_FALSE(b.discharge_overtemperature_protection.state);
+  EXPECT_FALSE(b.discharge_undertemperature_protection.state);
+  EXPECT_FALSE(b.charge_overcurrent_protection.state);
+  EXPECT_FALSE(b.discharge_overcurrent_protection.state);
+  EXPECT_FALSE(b.short_circuit_protection.state);
+  EXPECT_FALSE(b.ic_frontend_error.state);
+  EXPECT_FALSE(b.mosfet_software_lock.state);
 }
 
 TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsAllActive) {
-  TestableJbdBms bms;
-  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
-  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
-  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
-  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
-  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
-  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
-  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
-  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
-  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
-  bms.set_charge_overcurrent_protection_binary_sensor(&co);
-  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
-  bms.set_short_circuit_protection_binary_sensor(&sc);
-  bms.set_ic_frontend_error_binary_sensor(&ic);
-  bms.set_mosfet_software_lock_binary_sensor(&swl);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_ALL_PROTECTIONS);
-
-  EXPECT_TRUE(cov.state);
-  EXPECT_TRUE(cuv.state);
-  EXPECT_TRUE(pov.state);
-  EXPECT_TRUE(puv.state);
-  EXPECT_TRUE(cot.state);
-  EXPECT_TRUE(cut.state);
-  EXPECT_TRUE(dot.state);
-  EXPECT_TRUE(dut.state);
-  EXPECT_TRUE(co.state);
-  EXPECT_TRUE(doc.state);
-  EXPECT_TRUE(sc.state);
-  EXPECT_TRUE(ic.state);
-  EXPECT_TRUE(swl.state);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME_ALL_PROTECTIONS);
+  EXPECT_TRUE(b.cell_overvoltage_protection.state);
+  EXPECT_TRUE(b.cell_undervoltage_protection.state);
+  EXPECT_TRUE(b.pack_overvoltage_protection.state);
+  EXPECT_TRUE(b.pack_undervoltage_protection.state);
+  EXPECT_TRUE(b.charge_overtemperature_protection.state);
+  EXPECT_TRUE(b.charge_undertemperature_protection.state);
+  EXPECT_TRUE(b.discharge_overtemperature_protection.state);
+  EXPECT_TRUE(b.discharge_undertemperature_protection.state);
+  EXPECT_TRUE(b.charge_overcurrent_protection.state);
+  EXPECT_TRUE(b.discharge_overcurrent_protection.state);
+  EXPECT_TRUE(b.short_circuit_protection.state);
+  EXPECT_TRUE(b.ic_frontend_error.state);
+  EXPECT_TRUE(b.mosfet_software_lock.state);
 }
 
 TEST(JbdBmsHwInfoTest, ProtectionBinarySensorsByteOrder) {
-  TestableJbdBms bms;
-  binary_sensor::BinarySensor cov, cuv, pov, puv, cot, cut, dot, dut, co, doc, sc, ic, swl;
-  bms.set_cell_overvoltage_protection_binary_sensor(&cov);
-  bms.set_cell_undervoltage_protection_binary_sensor(&cuv);
-  bms.set_pack_overvoltage_protection_binary_sensor(&pov);
-  bms.set_pack_undervoltage_protection_binary_sensor(&puv);
-  bms.set_charge_overtemperature_protection_binary_sensor(&cot);
-  bms.set_charge_undertemperature_protection_binary_sensor(&cut);
-  bms.set_discharge_overtemperature_protection_binary_sensor(&dot);
-  bms.set_discharge_undertemperature_protection_binary_sensor(&dut);
-  bms.set_charge_overcurrent_protection_binary_sensor(&co);
-  bms.set_discharge_overcurrent_protection_binary_sensor(&doc);
-  bms.set_short_circuit_protection_binary_sensor(&sc);
-  bms.set_ic_frontend_error_binary_sensor(&ic);
-  bms.set_mosfet_software_lock_binary_sensor(&swl);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_MOSFET_SOFTWARE_LOCK);
-
-  EXPECT_FALSE(cov.state);
-  EXPECT_FALSE(cuv.state);
-  EXPECT_FALSE(pov.state);
-  EXPECT_FALSE(puv.state);
-  EXPECT_FALSE(cot.state);
-  EXPECT_FALSE(cut.state);
-  EXPECT_FALSE(dot.state);
-  EXPECT_FALSE(dut.state);
-  EXPECT_FALSE(co.state);
-  EXPECT_FALSE(doc.state);
-  EXPECT_FALSE(sc.state);
-  EXPECT_FALSE(ic.state);
-  EXPECT_TRUE(swl.state);
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME_MOSFET_SOFTWARE_LOCK);
+  EXPECT_FALSE(b.cell_overvoltage_protection.state);
+  EXPECT_FALSE(b.cell_undervoltage_protection.state);
+  EXPECT_FALSE(b.pack_overvoltage_protection.state);
+  EXPECT_FALSE(b.pack_undervoltage_protection.state);
+  EXPECT_FALSE(b.charge_overtemperature_protection.state);
+  EXPECT_FALSE(b.charge_undertemperature_protection.state);
+  EXPECT_FALSE(b.discharge_overtemperature_protection.state);
+  EXPECT_FALSE(b.discharge_undertemperature_protection.state);
+  EXPECT_FALSE(b.charge_overcurrent_protection.state);
+  EXPECT_FALSE(b.discharge_overcurrent_protection.state);
+  EXPECT_FALSE(b.short_circuit_protection.state);
+  EXPECT_FALSE(b.ic_frontend_error.state);
+  EXPECT_TRUE(b.mosfet_software_lock.state);
 }
 
 // ── Balancing cells text sensor ───────────────────────────────────────────────
 
 TEST(JbdBmsHwInfoTest, BalancingCellsEmpty) {
-  TestableJbdBms bms;
-  text_sensor::TextSensor balancing_cells;
-  bms.set_balancing_cells_text_sensor(&balancing_cells);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
-
-  EXPECT_EQ(balancing_cells.state, "");
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME);
+  EXPECT_EQ(b.balancing_cells_ts.state, "");
 }
 
 TEST(JbdBmsHwInfoTest, BalancingCellsActive) {
-  TestableJbdBms bms;
-  text_sensor::TextSensor balancing_cells;
-  bms.set_balancing_cells_text_sensor(&balancing_cells);
-
-  bms.on_jbd_bms_data(0x03, HWINFO_FRAME_BALANCING_CELLS_1_3);
-
-  EXPECT_EQ(balancing_cells.state, "1, 3");
+  JbdBmsTestBench b;
+  b.bms.on_jbd_bms_data(0x03, HWINFO_FRAME_BALANCING_CELLS_1_3);
+  EXPECT_EQ(b.balancing_cells_ts.state, "1, 3");
 }
 
 // ── Null sensors do not crash ─────────────────────────────────────────────────

--- a/tests/components/jbd_bms/test.esp32-idf.yaml
+++ b/tests/components/jbd_bms/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/jbd_bms/test.esp8266-ard.yaml
+++ b/tests/components/jbd_bms/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/jbd_bms/test.host.yaml
+++ b/tests/components/jbd_bms/test.host.yaml
@@ -6,3 +6,219 @@ jbd_bms:
   id: test_bms
   uart_id: uart_bus
   update_interval: 5s
+
+sensor:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    total_voltage:
+      name: Total Voltage
+    current:
+      name: Current
+    power:
+      name: Power
+    charging_power:
+      name: Charging Power
+    discharging_power:
+      name: Discharging Power
+    state_of_charge:
+      name: State of Charge
+    nominal_capacity:
+      name: Nominal Capacity
+    charging_cycles:
+      name: Charging Cycles
+    capacity_remaining:
+      name: Capacity Remaining
+    battery_cycle_capacity:
+      name: Battery Cycle Capacity
+    min_cell_voltage:
+      name: Min Cell Voltage
+    max_cell_voltage:
+      name: Max Cell Voltage
+    min_voltage_cell:
+      name: Min Voltage Cell
+    max_voltage_cell:
+      name: Max Voltage Cell
+    delta_cell_voltage:
+      name: Delta Cell Voltage
+    average_cell_voltage:
+      name: Average Cell Voltage
+    operation_status_bitmask:
+      name: Operation Status Bitmask
+    errors_bitmask:
+      name: Errors Bitmask
+    balancer_status_bitmask:
+      name: Balancer Status Bitmask
+    battery_strings:
+      name: Battery Strings
+    software_version:
+      name: Software Version
+    short_circuit_error_count:
+      name: Short Circuit Error Count
+    charge_overcurrent_error_count:
+      name: Charge Overcurrent Error Count
+    discharge_overcurrent_error_count:
+      name: Discharge Overcurrent Error Count
+    cell_overvoltage_error_count:
+      name: Cell Overvoltage Error Count
+    cell_undervoltage_error_count:
+      name: Cell Undervoltage Error Count
+    charge_overtemperature_error_count:
+      name: Charge Overtemperature Error Count
+    charge_undertemperature_error_count:
+      name: Charge Undertemperature Error Count
+    discharge_overtemperature_error_count:
+      name: Discharge Overtemperature Error Count
+    discharge_undertemperature_error_count:
+      name: Discharge Undertemperature Error Count
+    battery_overvoltage_error_count:
+      name: Battery Overvoltage Error Count
+    battery_undervoltage_error_count:
+      name: Battery Undervoltage Error Count
+    cell_voltage_1:
+      name: Cell Voltage 1
+    cell_voltage_2:
+      name: Cell Voltage 2
+    cell_voltage_3:
+      name: Cell Voltage 3
+    cell_voltage_4:
+      name: Cell Voltage 4
+    cell_voltage_5:
+      name: Cell Voltage 5
+    cell_voltage_6:
+      name: Cell Voltage 6
+    cell_voltage_7:
+      name: Cell Voltage 7
+    cell_voltage_8:
+      name: Cell Voltage 8
+    cell_voltage_9:
+      name: Cell Voltage 9
+    cell_voltage_10:
+      name: Cell Voltage 10
+    cell_voltage_11:
+      name: Cell Voltage 11
+    cell_voltage_12:
+      name: Cell Voltage 12
+    cell_voltage_13:
+      name: Cell Voltage 13
+    cell_voltage_14:
+      name: Cell Voltage 14
+    cell_voltage_15:
+      name: Cell Voltage 15
+    cell_voltage_16:
+      name: Cell Voltage 16
+    cell_voltage_17:
+      name: Cell Voltage 17
+    cell_voltage_18:
+      name: Cell Voltage 18
+    cell_voltage_19:
+      name: Cell Voltage 19
+    cell_voltage_20:
+      name: Cell Voltage 20
+    cell_voltage_21:
+      name: Cell Voltage 21
+    cell_voltage_22:
+      name: Cell Voltage 22
+    cell_voltage_23:
+      name: Cell Voltage 23
+    cell_voltage_24:
+      name: Cell Voltage 24
+    cell_voltage_25:
+      name: Cell Voltage 25
+    cell_voltage_26:
+      name: Cell Voltage 26
+    cell_voltage_27:
+      name: Cell Voltage 27
+    cell_voltage_28:
+      name: Cell Voltage 28
+    cell_voltage_29:
+      name: Cell Voltage 29
+    cell_voltage_30:
+      name: Cell Voltage 30
+    cell_voltage_31:
+      name: Cell Voltage 31
+    cell_voltage_32:
+      name: Cell Voltage 32
+    temperature_1:
+      name: Temperature 1
+    temperature_2:
+      name: Temperature 2
+    temperature_3:
+      name: Temperature 3
+    temperature_4:
+      name: Temperature 4
+    temperature_5:
+      name: Temperature 5
+    temperature_6:
+      name: Temperature 6
+
+binary_sensor:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    charging:
+      name: Charging
+    discharging:
+      name: Discharging
+    balancing:
+      name: Balancing
+    online_status:
+      name: Online Status
+    cell_overvoltage_protection:
+      name: Cell Overvoltage Protection
+    cell_undervoltage_protection:
+      name: Cell Undervoltage Protection
+    pack_overvoltage_protection:
+      name: Pack Overvoltage Protection
+    pack_undervoltage_protection:
+      name: Pack Undervoltage Protection
+    charge_overtemperature_protection:
+      name: Charge Overtemperature Protection
+    charge_undertemperature_protection:
+      name: Charge Undertemperature Protection
+    discharge_overtemperature_protection:
+      name: Discharge Overtemperature Protection
+    discharge_undertemperature_protection:
+      name: Discharge Undertemperature Protection
+    charge_overcurrent_protection:
+      name: Charge Overcurrent Protection
+    discharge_overcurrent_protection:
+      name: Discharge Overcurrent Protection
+    short_circuit_protection:
+      name: Short Circuit Protection
+    ic_frontend_error:
+      name: IC Frontend Error
+    mosfet_software_lock:
+      name: MOSFET Software Lock
+
+text_sensor:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    errors:
+      name: Errors
+    operation_status:
+      name: Operation Status
+    device_model:
+      name: Device Model
+    balancing_cells:
+      name: Balancing Cells
+
+switch:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    charging:
+      name: Charging Switch
+    discharging:
+      name: Discharging Switch
+
+button:
+  - platform: jbd_bms
+    jbd_bms_id: test_bms
+    retrieve_hardware_version:
+      name: Retrieve Hardware Version
+    retrieve_error_counts:
+      name: Retrieve Error Counts
+    force_soc_reset:
+      name: Force SOC Reset
+    automatic_balancing:
+      name: Automatic Balancing
+    clear_alarm:
+      name: Clear Alarm


### PR DESCRIPTION
## Summary

- Adds `tests/components/jbd_bms/common.yaml` listing every sensor, binary sensor, text sensor, switch and button so that code generation (`to_code`) is exercised via `esphome config` in CI.
- Adds `test.esp8266-ard.yaml` and `test.esp32-idf.yaml` as thin platform wrappers that pull in the UART bus via the shared `test_build_components/common/uart` packages and include `common.yaml`.
- Adds a new CI step "Validate component test configurations" to the `esphome-config` job that runs `esphome config` on each `test.*.yaml`.

**The second commit contains a deliberate error** (`this_sensor_does_not_exist`) in `common.yaml` to prove that the CI step actually reads and validates the file. The CI should fail on that step with an extra-key validation error. This commit must be reverted before merging.

## Why

The existing `tests/test_component_schemas.py` only checks that Python dicts have the right keys — it never exercises code generation. A typo in a `to_code()` setter call or a missing `if key in config:` branch would go undetected. The YAML approach catches those regressions at config-validation time.

## Test plan

- [ ] Verify CI fails on the second commit with an error for `this_sensor_does_not_exist`
- [ ] Revert the second commit and verify CI passes
- [ ] Confirm the `Validate component test configurations` step appears in the CI log
