### PR TITLE
Decode all remaining pack status fields in jbd_bms_up_pack

### DIFF
--- a/components/jbd_bms_up_pack/binary_sensor.py
+++ b/components/jbd_bms_up_pack/binary_sensor.py
@@ -9,6 +9,7 @@ DEPENDENCIES = ["jbd_bms_up_pack"]
 
 CODEOWNERS = ["@syssi"]
 
+CONF_BALANCING = "balancing"
 CONF_CHARGING = "charging"
 CONF_DISCHARGING = "discharging"
 CONF_PRECHARGING = "precharging"
@@ -16,6 +17,7 @@ CONF_HEAT = "heat"
 CONF_FAN = "fan"
 CONF_ONLINE_STATUS = "online_status"
 
+ICON_BALANCING = "mdi:seesaw"
 ICON_CHARGING = "mdi:battery-charging"
 ICON_DISCHARGING = "mdi:power-plug"
 ICON_PRECHARGING = "mdi:battery-charging-10"
@@ -23,6 +25,7 @@ ICON_HEAT = "mdi:radiator"
 ICON_FAN = "mdi:fan"
 
 BINARY_SENSOR_DEFS = {
+    CONF_BALANCING: {"icon": ICON_BALANCING},
     CONF_CHARGING: {"icon": ICON_CHARGING},
     CONF_DISCHARGING: {"icon": ICON_DISCHARGING},
     CONF_PRECHARGING: {"icon": ICON_PRECHARGING},

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
@@ -205,22 +205,18 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
   for (uint8_t i = 0; i < temperature_sensor_publish_count; i++) {
     this->publish_state_(temperature_sensors_[i], (jbd_get_16bit(offset + 2 * i) - 500) * 0.1f);
   }
-  offset = offset + 2 * temperature_sensor_count;
+  offset = offset + 2 * temperature_sensor_count + 6;
 
-  if (data.size() >= offset + 6) {
-    uint16_t balance_status = jbd_get_16bit(offset + 2);
+  if (data.size() >= offset + 30) {
+    uint16_t balance_status = jbd_get_16bit(offset - 4);
     this->publish_state_(balancing_bitmask_sensor_, (float) balance_status);
     this->publish_state_(balancing_binary_sensor_, balance_status != 0);
-    uint16_t firmware_version_raw = jbd_get_16bit(offset + 4);
+    uint16_t firmware_version_raw = jbd_get_16bit(offset - 2);
     uint8_t version_major = firmware_version_raw >> 8;
     uint8_t version_minor = firmware_version_raw & 0xFF;
     char version_str[8];
     snprintf(version_str, sizeof(version_str), "%d.%d", version_major, version_minor);
     this->publish_state_(firmware_version_text_sensor_, std::string(version_str));
-  }
-  offset += 6;
-
-  if (data.size() >= offset + 30) {
     std::string model(data.begin() + offset, data.begin() + offset + 30);
     auto null_pos = model.find('\0');
     if (null_pos != std::string::npos) {

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
@@ -211,10 +211,12 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
     uint16_t balance_status = jbd_get_16bit(offset + 2);
     this->publish_state_(balancing_bitmask_sensor_, (float) balance_status);
     this->publish_state_(balancing_binary_sensor_, balance_status != 0);
-    uint16_t fw = jbd_get_16bit(offset + 4);
-    char fw_str[8];
-    snprintf(fw_str, sizeof(fw_str), "%d.%d", fw >> 8, fw & 0xFF);
-    this->publish_state_(firmware_version_text_sensor_, std::string(fw_str));
+    uint16_t firmware_version_raw = jbd_get_16bit(offset + 4);
+    uint8_t version_major = firmware_version_raw >> 8;
+    uint8_t version_minor = firmware_version_raw & 0xFF;
+    char version_str[8];
+    snprintf(version_str, sizeof(version_str), "%d.%d", version_major, version_minor);
+    this->publish_state_(firmware_version_text_sensor_, std::string(version_str));
   }
   offset += 6;
 

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
@@ -121,6 +121,7 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
   this->publish_state_(state_of_charge_sensor_, jbd_get_16bit(8) * 0.01f);
   this->publish_state_(capacity_remaining_sensor_, jbd_get_16bit(10) * 0.01f);
   this->publish_state_(nominal_capacity_sensor_, jbd_get_16bit(12) * 0.01f);
+  this->publish_state_(rated_capacity_sensor_, jbd_get_16bit(14) * 0.01f);
 
   this->publish_state_(mosfet_temperature_sensor_, (jbd_get_16bit(16) - 500) * 0.1f);
   this->publish_state_(ambient_temperature_sensor_, (jbd_get_16bit(18) - 500) * 0.1f);
@@ -155,8 +156,10 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
   // Byte layout verified against UP16S020 raw capture (FC=0x78, reg=0x1000):
   // [38-39] max_voltage_cell index (1-based), [40-41] max_cell_voltage mV
   // [42-43] min_voltage_cell index, [44-45] min_cell_voltage mV
-  // [46-47] average_cell_voltage mV, [48-65] reserved (18 bytes)
-  // [66-67] cell count, [68+] cell voltage array
+  // [46-47] average_cell_voltage mV, [48-49] max_temp_sensor index
+  // [50-51] max_temperature, [52-53] min_temp_sensor index, [54-55] min_temperature
+  // [56-57] average_temperature, [58-59] CVL V/10, [60-61] CCL A/10
+  // [62-63] DVL V/10, [64-65] DCL A/10, [66-67] cell count, [68+] cell voltage array
   this->publish_state_(max_voltage_cell_sensor_, (float) jbd_get_16bit(38));
   float max_cell_v = jbd_get_16bit(40) * 0.001f;
   this->publish_state_(max_cell_voltage_sensor_, max_cell_v);
@@ -165,6 +168,14 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
   this->publish_state_(min_cell_voltage_sensor_, min_cell_v);
   this->publish_state_(average_cell_voltage_sensor_, jbd_get_16bit(46) * 0.001f);
   this->publish_state_(delta_cell_voltage_sensor_, max_cell_v - min_cell_v);
+
+  this->publish_state_(max_temperature_sensor_, (jbd_get_16bit(50) - 500) * 0.1f);
+  this->publish_state_(min_temperature_sensor_, (jbd_get_16bit(54) - 500) * 0.1f);
+  this->publish_state_(average_temperature_sensor_, (jbd_get_16bit(56) - 500) * 0.1f);
+  this->publish_state_(charge_voltage_limit_sensor_, jbd_get_16bit(58) * 0.1f);
+  this->publish_state_(charge_current_limit_sensor_, jbd_get_16bit(60) * 0.1f);
+  this->publish_state_(discharge_voltage_limit_sensor_, jbd_get_16bit(62) * 0.1f);
+  this->publish_state_(discharge_current_limit_sensor_, jbd_get_16bit(64) * 0.1f);
 
   if (data.size() < 68) {
     return;
@@ -194,7 +205,18 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
   for (uint8_t i = 0; i < temperature_sensor_publish_count; i++) {
     this->publish_state_(temperature_sensors_[i], (jbd_get_16bit(offset + 2 * i) - 500) * 0.1f);
   }
-  offset = offset + 2 * temperature_sensor_count + 6;
+  offset = offset + 2 * temperature_sensor_count;
+
+  if (data.size() >= offset + 6) {
+    uint16_t balance_status = jbd_get_16bit(offset + 2);
+    this->publish_state_(balancing_bitmask_sensor_, (float) balance_status);
+    this->publish_state_(balancing_binary_sensor_, balance_status != 0);
+    uint16_t fw = jbd_get_16bit(offset + 4);
+    char fw_str[8];
+    snprintf(fw_str, sizeof(fw_str), "%d.%d", fw >> 8, fw & 0xFF);
+    this->publish_state_(firmware_version_text_sensor_, std::string(fw_str));
+  }
+  offset += 6;
 
   if (data.size() >= offset + 30) {
     std::string model(data.begin() + offset, data.begin() + offset + 30);
@@ -233,8 +255,12 @@ void JbdBmsUpPack::dump_config() {
   LOG_SENSOR("", "State of Charge", this->state_of_charge_sensor_);
   LOG_SENSOR("", "Capacity Remaining", this->capacity_remaining_sensor_);
   LOG_SENSOR("", "Nominal Capacity", this->nominal_capacity_sensor_);
+  LOG_SENSOR("", "Rated Capacity", this->rated_capacity_sensor_);
   LOG_SENSOR("", "Mosfet Temperature", this->mosfet_temperature_sensor_);
   LOG_SENSOR("", "Ambient Temperature", this->ambient_temperature_sensor_);
+  LOG_SENSOR("", "Max Temperature", this->max_temperature_sensor_);
+  LOG_SENSOR("", "Min Temperature", this->min_temperature_sensor_);
+  LOG_SENSOR("", "Average Temperature", this->average_temperature_sensor_);
   LOG_SENSOR("", "State of Health", this->state_of_health_sensor_);
   LOG_SENSOR("", "Operation Status Bitmask", this->operation_status_bitmask_sensor_);
   LOG_SENSOR("", "Errors Bitmask", this->errors_bitmask_sensor_);
@@ -247,12 +273,19 @@ void JbdBmsUpPack::dump_config() {
   LOG_SENSOR("", "Delta Cell Voltage", this->delta_cell_voltage_sensor_);
   LOG_SENSOR("", "Average Cell Voltage", this->average_cell_voltage_sensor_);
   LOG_SENSOR("", "Battery Strings", this->battery_strings_sensor_);
+  LOG_SENSOR("", "Charge Voltage Limit", this->charge_voltage_limit_sensor_);
+  LOG_SENSOR("", "Charge Current Limit", this->charge_current_limit_sensor_);
+  LOG_SENSOR("", "Discharge Voltage Limit", this->discharge_voltage_limit_sensor_);
+  LOG_SENSOR("", "Discharge Current Limit", this->discharge_current_limit_sensor_);
+  LOG_SENSOR("", "Balancing Bitmask", this->balancing_bitmask_sensor_);
+  LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Precharging", this->precharging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Heat", this->heat_binary_sensor_);
   LOG_BINARY_SENSOR("", "Fan", this->fan_binary_sensor_);
   LOG_BINARY_SENSOR("", "Online Status", this->online_status_binary_sensor_);
+  LOG_TEXT_SENSOR("", "Firmware Version", this->firmware_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
   LOG_TEXT_SENSOR("", "Protect", this->protect_text_sensor_);

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.h
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.h
@@ -110,17 +110,39 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
     device_model_text_sensor_ = device_model_text_sensor;
   }
 
-  void set_rated_capacity_sensor(sensor::Sensor *s) { rated_capacity_sensor_ = s; }
-  void set_max_temperature_sensor(sensor::Sensor *s) { max_temperature_sensor_ = s; }
-  void set_min_temperature_sensor(sensor::Sensor *s) { min_temperature_sensor_ = s; }
-  void set_average_temperature_sensor(sensor::Sensor *s) { average_temperature_sensor_ = s; }
-  void set_charge_voltage_limit_sensor(sensor::Sensor *s) { charge_voltage_limit_sensor_ = s; }
-  void set_charge_current_limit_sensor(sensor::Sensor *s) { charge_current_limit_sensor_ = s; }
-  void set_discharge_voltage_limit_sensor(sensor::Sensor *s) { discharge_voltage_limit_sensor_ = s; }
-  void set_discharge_current_limit_sensor(sensor::Sensor *s) { discharge_current_limit_sensor_ = s; }
-  void set_balancing_bitmask_sensor(sensor::Sensor *s) { balancing_bitmask_sensor_ = s; }
-  void set_balancing_binary_sensor(binary_sensor::BinarySensor *s) { balancing_binary_sensor_ = s; }
-  void set_firmware_version_text_sensor(text_sensor::TextSensor *s) { firmware_version_text_sensor_ = s; }
+  void set_rated_capacity_sensor(sensor::Sensor *rated_capacity_sensor) {
+    rated_capacity_sensor_ = rated_capacity_sensor;
+  }
+  void set_max_temperature_sensor(sensor::Sensor *max_temperature_sensor) {
+    max_temperature_sensor_ = max_temperature_sensor;
+  }
+  void set_min_temperature_sensor(sensor::Sensor *min_temperature_sensor) {
+    min_temperature_sensor_ = min_temperature_sensor;
+  }
+  void set_average_temperature_sensor(sensor::Sensor *average_temperature_sensor) {
+    average_temperature_sensor_ = average_temperature_sensor;
+  }
+  void set_charge_voltage_limit_sensor(sensor::Sensor *charge_voltage_limit_sensor) {
+    charge_voltage_limit_sensor_ = charge_voltage_limit_sensor;
+  }
+  void set_charge_current_limit_sensor(sensor::Sensor *charge_current_limit_sensor) {
+    charge_current_limit_sensor_ = charge_current_limit_sensor;
+  }
+  void set_discharge_voltage_limit_sensor(sensor::Sensor *discharge_voltage_limit_sensor) {
+    discharge_voltage_limit_sensor_ = discharge_voltage_limit_sensor;
+  }
+  void set_discharge_current_limit_sensor(sensor::Sensor *discharge_current_limit_sensor) {
+    discharge_current_limit_sensor_ = discharge_current_limit_sensor;
+  }
+  void set_balancing_bitmask_sensor(sensor::Sensor *balancing_bitmask_sensor) {
+    balancing_bitmask_sensor_ = balancing_bitmask_sensor;
+  }
+  void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
+    balancing_binary_sensor_ = balancing_binary_sensor;
+  }
+  void set_firmware_version_text_sensor(text_sensor::TextSensor *firmware_version_text_sensor) {
+    firmware_version_text_sensor_ = firmware_version_text_sensor;
+  }
 
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.h
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.h
@@ -110,6 +110,18 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
     device_model_text_sensor_ = device_model_text_sensor;
   }
 
+  void set_rated_capacity_sensor(sensor::Sensor *s) { rated_capacity_sensor_ = s; }
+  void set_max_temperature_sensor(sensor::Sensor *s) { max_temperature_sensor_ = s; }
+  void set_min_temperature_sensor(sensor::Sensor *s) { min_temperature_sensor_ = s; }
+  void set_average_temperature_sensor(sensor::Sensor *s) { average_temperature_sensor_ = s; }
+  void set_charge_voltage_limit_sensor(sensor::Sensor *s) { charge_voltage_limit_sensor_ = s; }
+  void set_charge_current_limit_sensor(sensor::Sensor *s) { charge_current_limit_sensor_ = s; }
+  void set_discharge_voltage_limit_sensor(sensor::Sensor *s) { discharge_voltage_limit_sensor_ = s; }
+  void set_discharge_current_limit_sensor(sensor::Sensor *s) { discharge_current_limit_sensor_ = s; }
+  void set_balancing_bitmask_sensor(sensor::Sensor *s) { balancing_bitmask_sensor_ = s; }
+  void set_balancing_binary_sensor(binary_sensor::BinarySensor *s) { balancing_binary_sensor_ = s; }
+  void set_firmware_version_text_sensor(text_sensor::TextSensor *s) { firmware_version_text_sensor_ = s; }
+
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
 
@@ -130,8 +142,12 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
   sensor::Sensor *state_of_charge_sensor_{nullptr};
   sensor::Sensor *capacity_remaining_sensor_{nullptr};
   sensor::Sensor *nominal_capacity_sensor_{nullptr};
+  sensor::Sensor *rated_capacity_sensor_{nullptr};
   sensor::Sensor *mosfet_temperature_sensor_{nullptr};
   sensor::Sensor *ambient_temperature_sensor_{nullptr};
+  sensor::Sensor *max_temperature_sensor_{nullptr};
+  sensor::Sensor *min_temperature_sensor_{nullptr};
+  sensor::Sensor *average_temperature_sensor_{nullptr};
   sensor::Sensor *state_of_health_sensor_{nullptr};
   sensor::Sensor *operation_status_bitmask_sensor_{nullptr};
   sensor::Sensor *errors_bitmask_sensor_{nullptr};
@@ -144,9 +160,15 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
   sensor::Sensor *delta_cell_voltage_sensor_{nullptr};
   sensor::Sensor *average_cell_voltage_sensor_{nullptr};
   sensor::Sensor *battery_strings_sensor_{nullptr};
+  sensor::Sensor *charge_voltage_limit_sensor_{nullptr};
+  sensor::Sensor *charge_current_limit_sensor_{nullptr};
+  sensor::Sensor *discharge_voltage_limit_sensor_{nullptr};
+  sensor::Sensor *discharge_current_limit_sensor_{nullptr};
+  sensor::Sensor *balancing_bitmask_sensor_{nullptr};
   sensor::Sensor *cell_voltage_sensors_[32]{};
   sensor::Sensor *temperature_sensors_[6]{};
 
+  binary_sensor::BinarySensor *balancing_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *precharging_binary_sensor_{nullptr};
@@ -154,6 +176,7 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
   binary_sensor::BinarySensor *fan_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
 
+  text_sensor::TextSensor *firmware_version_text_sensor_{nullptr};
   text_sensor::TextSensor *operation_status_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
   text_sensor::TextSensor *protect_text_sensor_{nullptr};

--- a/components/jbd_bms_up_pack/sensor.py
+++ b/components/jbd_bms_up_pack/sensor.py
@@ -3,6 +3,8 @@ from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CURRENT,
+    CONF_MAX_TEMPERATURE,
+    CONF_MIN_TEMPERATURE,
     CONF_POWER,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CURRENT,
@@ -37,8 +39,6 @@ CONF_NOMINAL_CAPACITY = "nominal_capacity"
 CONF_RATED_CAPACITY = "rated_capacity"
 CONF_MOSFET_TEMPERATURE = "mosfet_temperature"
 CONF_AMBIENT_TEMPERATURE = "ambient_temperature"
-CONF_MAX_TEMPERATURE = "max_temperature"
-CONF_MIN_TEMPERATURE = "min_temperature"
 CONF_AVERAGE_TEMPERATURE = "average_temperature"
 CONF_STATE_OF_HEALTH = "state_of_health"
 CONF_OPERATION_STATUS_BITMASK = "operation_status_bitmask"

--- a/components/jbd_bms_up_pack/sensor.py
+++ b/components/jbd_bms_up_pack/sensor.py
@@ -34,8 +34,12 @@ CONF_DISCHARGING_POWER = "discharging_power"
 CONF_STATE_OF_CHARGE = "state_of_charge"
 CONF_CAPACITY_REMAINING = "capacity_remaining"
 CONF_NOMINAL_CAPACITY = "nominal_capacity"
+CONF_RATED_CAPACITY = "rated_capacity"
 CONF_MOSFET_TEMPERATURE = "mosfet_temperature"
 CONF_AMBIENT_TEMPERATURE = "ambient_temperature"
+CONF_MAX_TEMPERATURE = "max_temperature"
+CONF_MIN_TEMPERATURE = "min_temperature"
+CONF_AVERAGE_TEMPERATURE = "average_temperature"
 CONF_STATE_OF_HEALTH = "state_of_health"
 CONF_OPERATION_STATUS_BITMASK = "operation_status_bitmask"
 CONF_ERRORS_BITMASK = "errors_bitmask"
@@ -48,6 +52,11 @@ CONF_MAX_VOLTAGE_CELL = "max_voltage_cell"
 CONF_DELTA_CELL_VOLTAGE = "delta_cell_voltage"
 CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
 CONF_BATTERY_STRINGS = "battery_strings"
+CONF_CHARGE_VOLTAGE_LIMIT = "charge_voltage_limit"
+CONF_CHARGE_CURRENT_LIMIT = "charge_current_limit"
+CONF_DISCHARGE_VOLTAGE_LIMIT = "discharge_voltage_limit"
+CONF_DISCHARGE_CURRENT_LIMIT = "discharge_current_limit"
+CONF_BALANCING_BITMASK = "balancing_bitmask"
 
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
@@ -61,6 +70,7 @@ ICON_OPERATION_STATUS_BITMASK = "mdi:heart-pulse"
 ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_PROTECT_BITMASK = "mdi:shield-alert-outline"
 ICON_BATTERY_STRINGS = "mdi:car-battery"
+ICON_BALANCING_BITMASK = "mdi:seesaw"
 
 UNIT_AMPERE_HOURS = "Ah"
 
@@ -123,6 +133,14 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
+    CONF_RATED_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_NOMINAL_CAPACITY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
     CONF_MOSFET_TEMPERATURE: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
@@ -131,6 +149,27 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_AMBIENT_TEMPERATURE: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_TEMPERATURE: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_TEMPERATURE: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AVERAGE_TEMPERATURE: {
         "unit_of_measurement": UNIT_CELSIUS,
         "icon": ICON_EMPTY,
         "accuracy_decimals": 1,
@@ -220,6 +259,46 @@ SENSOR_DEFS = {
     CONF_BATTERY_STRINGS: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_BATTERY_STRINGS,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_VOLTAGE_LIMIT: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_CURRENT_LIMIT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_CURRENT_DC,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_VOLTAGE_LIMIT: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_CURRENT_LIMIT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_CURRENT_DC,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BALANCING_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BALANCING_BITMASK,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/jbd_bms_up_pack/text_sensor.py
+++ b/components/jbd_bms_up_pack/text_sensor.py
@@ -9,12 +9,17 @@ DEPENDENCIES = ["jbd_bms_up_pack"]
 
 CODEOWNERS = ["@syssi"]
 
+CONF_FIRMWARE_VERSION = "firmware_version"
 CONF_OPERATION_STATUS = "operation_status"
 CONF_ERRORS = "errors"
 CONF_PROTECT = "protect"
 CONF_DEVICE_MODEL = "device_model"
 
 TEXT_SENSOR_DEFS = {
+    CONF_FIRMWARE_VERSION: {
+        "icon": "mdi:tag",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_OPERATION_STATUS: {"icon": "mdi:heart-pulse"},
     CONF_ERRORS: {
         "icon": "mdi:alert-circle-outline",

--- a/esp32-up-example.yaml
+++ b/esp32-up-example.yaml
@@ -57,6 +57,8 @@ jbd_bms_up_pack:
 binary_sensor:
   - platform: jbd_bms_up_pack
     jbd_bms_up_pack_id: bms0
+    balancing:
+      name: "${name} balancing"
     charging:
       name: "${name} charging"
     discharging:
@@ -91,12 +93,28 @@ sensor:
       name: "${name} capacity remaining"
     nominal_capacity:
       name: "${name} nominal capacity"
+    rated_capacity:
+      name: "${name} rated capacity"
     charging_cycles:
       name: "${name} charging cycles"
     mosfet_temperature:
       name: "${name} mosfet temperature"
     ambient_temperature:
       name: "${name} ambient temperature"
+    max_temperature:
+      name: "${name} max temperature"
+    min_temperature:
+      name: "${name} min temperature"
+    average_temperature:
+      name: "${name} average temperature"
+    charge_voltage_limit:
+      name: "${name} charge voltage limit"
+    charge_current_limit:
+      name: "${name} charge current limit"
+    discharge_voltage_limit:
+      name: "${name} discharge voltage limit"
+    discharge_current_limit:
+      name: "${name} discharge current limit"
     min_cell_voltage:
       name: "${name} min cell voltage"
     max_cell_voltage:
@@ -117,6 +135,8 @@ sensor:
       name: "${name} errors bitmask"
     protect_bitmask:
       name: "${name} protect bitmask"
+    balancing_bitmask:
+      name: "${name} balancing bitmask"
     cell_voltage_1:
       name: "${name} cell voltage 1"
     cell_voltage_2:
@@ -205,6 +225,8 @@ switch:
 text_sensor:
   - platform: jbd_bms_up_pack
     jbd_bms_up_pack_id: bms0
+    firmware_version:
+      name: "${name} firmware version"
     operation_status:
       name: "${name} operation status"
     errors:

--- a/tests/components/jbd_bms_up/frames.h
+++ b/tests/components/jbd_bms_up/frames.h
@@ -136,8 +136,6 @@ static const std::vector<uint8_t> PACK_STATUS_RESPONSE_ADDR2 = {
 static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8,
                                                           PACK_STATUS_RESPONSE_ADDR2.end() - 2);
 
-#endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
-
 // ── Charging variant ──────────────────────────────────────────────────────────
 // current = +50.00A → val = 305000 = 0x0004A768
 // operation_status = 1 (Charging), MOSFET = 0x0002 (CHG only)
@@ -164,5 +162,7 @@ static std::vector<uint8_t> make_pack_status_with_errors() {
   f[31] = 0x01;  // errors low word  = 0x0001 (bit0  = cell overvoltage)
   return f;
 }
+
+#endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
 
 }  // namespace esphome::jbd_bms_up::testing

--- a/tests/components/jbd_bms_up_pack/frames.h
+++ b/tests/components/jbd_bms_up_pack/frames.h
@@ -136,8 +136,6 @@ static const std::vector<uint8_t> PACK_STATUS_RESPONSE_ADDR2 = {
 static const std::vector<uint8_t> PACK_STATUS_FRAME_ADDR2(PACK_STATUS_RESPONSE_ADDR2.begin() + 8,
                                                           PACK_STATUS_RESPONSE_ADDR2.end() - 2);
 
-#endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
-
 // ── Charging variant ──────────────────────────────────────────────────────────
 // current = +50.00A → val = 305000 = 0x0004A768
 // operation_status = 1 (Charging), MOSFET = 0x0002 (CHG only)
@@ -165,14 +163,19 @@ static std::vector<uint8_t> make_pack_status_with_errors() {
   return f;
 }
 
+#endif  // JBD_BMS_PACK_STATUS_FRAMES_DEFINED
+
 // ── Balancing variant ─────────────────────────────────────────────────────────
 // balance_status = 0x0003: bits 0+1 set → cells 1 and 2 balancing.
 // Offset 112 = (68 + 16*2) + 2 + 4*2 + 2 = 116 - 4 for the 16S/4T frame.
+#ifndef JBD_BMS_PACK_STATUS_BALANCING_DEFINED
+#define JBD_BMS_PACK_STATUS_BALANCING_DEFINED
 static std::vector<uint8_t> make_pack_status_balancing() {
   auto f = PACK_STATUS_FRAME;
   f[112] = 0x00;
   f[113] = 0x03;
   return f;
 }
+#endif  // JBD_BMS_PACK_STATUS_BALANCING_DEFINED
 
 }  // namespace esphome::jbd_bms_up::testing

--- a/tests/components/jbd_bms_up_pack/frames.h
+++ b/tests/components/jbd_bms_up_pack/frames.h
@@ -165,4 +165,14 @@ static std::vector<uint8_t> make_pack_status_with_errors() {
   return f;
 }
 
+// ── Balancing variant ─────────────────────────────────────────────────────────
+// balance_status = 0x0003: bits 0+1 set → cells 1 and 2 balancing.
+// Offset 112 = (68 + 16*2) + 2 + 4*2 + 2 = 116 - 4 for the 16S/4T frame.
+static std::vector<uint8_t> make_pack_status_balancing() {
+  auto f = PACK_STATUS_FRAME;
+  f[112] = 0x00;
+  f[113] = 0x03;
+  return f;
+}
+
 }  // namespace esphome::jbd_bms_up::testing

--- a/tests/components/jbd_bms_up_pack/pack_status_test.cpp
+++ b/tests/components/jbd_bms_up_pack/pack_status_test.cpp
@@ -6,6 +6,7 @@ namespace esphome::jbd_bms_up_pack::testing {
 
 using esphome::jbd_bms_up::testing::PACK_STATUS_FRAME;
 using esphome::jbd_bms_up::testing::PACK_STATUS_FRAME_ADDR2;
+using esphome::jbd_bms_up::testing::make_pack_status_balancing;
 using esphome::jbd_bms_up::testing::make_pack_status_charging;
 using esphome::jbd_bms_up::testing::make_pack_status_with_errors;
 
@@ -222,6 +223,122 @@ TEST(PackStatusTest, CellVoltages) {
   }
 }
 
+// ── Rated capacity ────────────────────────────────────────────────────────────
+
+TEST(PackStatusTest, RatedCapacity) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor rated;
+  pack.set_rated_capacity_sensor(&rated);
+  pack.on_pack_status_(PACK_STATUS_FRAME);
+  EXPECT_NEAR(rated.state, 100.00f, 0.01f);
+}
+
+TEST(PackStatusTest, Addr2RatedCapacity) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor rated;
+  pack.set_rated_capacity_sensor(&rated);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(rated.state, 100.00f, 0.01f);
+}
+
+// ── Temperature aggregates ────────────────────────────────────────────────────
+
+TEST(PackStatusTest, TemperatureAggregates) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor max_t, min_t, avg_t;
+  pack.set_max_temperature_sensor(&max_t);
+  pack.set_min_temperature_sensor(&min_t);
+  pack.set_average_temperature_sensor(&avg_t);
+  pack.on_pack_status_(PACK_STATUS_FRAME);
+  EXPECT_NEAR(max_t.state, 21.2f, 0.1f);
+  EXPECT_NEAR(min_t.state, 20.4f, 0.1f);
+  EXPECT_NEAR(avg_t.state, 20.8f, 0.1f);
+}
+
+TEST(PackStatusTest, Addr2TemperatureAggregates) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor max_t, min_t, avg_t;
+  pack.set_max_temperature_sensor(&max_t);
+  pack.set_min_temperature_sensor(&min_t);
+  pack.set_average_temperature_sensor(&avg_t);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(max_t.state, 22.0f, 0.1f);
+  EXPECT_NEAR(min_t.state, 21.3f, 0.1f);
+  EXPECT_NEAR(avg_t.state, 21.6f, 0.1f);
+}
+
+// ── Charge/discharge limits ───────────────────────────────────────────────────
+
+TEST(PackStatusTest, ChargeDischargeLimits) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor cvl, ccl, dvl, dcl;
+  pack.set_charge_voltage_limit_sensor(&cvl);
+  pack.set_charge_current_limit_sensor(&ccl);
+  pack.set_discharge_voltage_limit_sensor(&dvl);
+  pack.set_discharge_current_limit_sensor(&dcl);
+  pack.on_pack_status_(PACK_STATUS_FRAME);
+  EXPECT_NEAR(cvl.state, 58.4f, 0.1f);
+  EXPECT_NEAR(ccl.state, 200.0f, 0.1f);
+  EXPECT_NEAR(dvl.state, 44.8f, 0.1f);
+  EXPECT_NEAR(dcl.state, 200.0f, 0.1f);
+}
+
+TEST(PackStatusTest, Addr2ChargeDischargeLimits) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor cvl, ccl, dvl, dcl;
+  pack.set_charge_voltage_limit_sensor(&cvl);
+  pack.set_charge_current_limit_sensor(&ccl);
+  pack.set_discharge_voltage_limit_sensor(&dvl);
+  pack.set_discharge_current_limit_sensor(&dcl);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_NEAR(cvl.state, 58.4f, 0.1f);
+  EXPECT_NEAR(ccl.state, 100.0f, 0.1f);
+  EXPECT_NEAR(dvl.state, 44.8f, 0.1f);
+  EXPECT_NEAR(dcl.state, 100.0f, 0.1f);
+}
+
+// ── Balancing ─────────────────────────────────────────────────────────────────
+
+TEST(PackStatusTest, BalancingNotActive) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor bitmask;
+  binary_sensor::BinarySensor active;
+  pack.set_balancing_bitmask_sensor(&bitmask);
+  pack.set_balancing_binary_sensor(&active);
+  pack.on_pack_status_(PACK_STATUS_FRAME);
+  EXPECT_FLOAT_EQ(bitmask.state, 0.0f);
+  EXPECT_FALSE(active.state);
+}
+
+TEST(PackStatusTest, BalancingActive) {
+  TestableJbdBmsUpPack pack;
+  sensor::Sensor bitmask;
+  binary_sensor::BinarySensor active;
+  pack.set_balancing_bitmask_sensor(&bitmask);
+  pack.set_balancing_binary_sensor(&active);
+  pack.on_pack_status_(make_pack_status_balancing());
+  EXPECT_FLOAT_EQ(bitmask.state, 3.0f);  // bits 0+1 → cells 1 and 2
+  EXPECT_TRUE(active.state);
+}
+
+// ── Firmware version ──────────────────────────────────────────────────────────
+
+TEST(PackStatusTest, FirmwareVersion) {
+  TestableJbdBmsUpPack pack;
+  text_sensor::TextSensor fw;
+  pack.set_firmware_version_text_sensor(&fw);
+  pack.on_pack_status_(PACK_STATUS_FRAME);
+  EXPECT_EQ(fw.state, "12.4");
+}
+
+TEST(PackStatusTest, Addr2FirmwareVersion) {
+  TestableJbdBmsUpPack pack;
+  text_sensor::TextSensor fw;
+  pack.set_firmware_version_text_sensor(&fw);
+  pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
+  EXPECT_EQ(fw.state, "0.4");
+}
+
 // ── Device model ──────────────────────────────────────────────────────────────
 
 TEST(PackStatusTest, DeviceModel) {
@@ -296,6 +413,7 @@ TEST(PackStatusTest, NullSensorsDoNotCrash) {
   pack.on_pack_status_(PACK_STATUS_FRAME_ADDR2);
   pack.on_pack_status_(make_pack_status_charging());
   pack.on_pack_status_(make_pack_status_with_errors());
+  pack.on_pack_status_(make_pack_status_balancing());
 }
 
 TEST(PackStatusTest, ShortFrameDoesNotCrash) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import importlib.util
+import os
+import sys
+
+project_root = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, project_root)
+
+# jbd_bms_up is a custom component, not part of the installed esphome package.
+# Inject it so that jbd_bms_up_pack can resolve "from esphome.components import jbd_bms_up".
+_init_path = os.path.join(project_root, "components", "jbd_bms_up", "__init__.py")
+_spec = importlib.util.spec_from_file_location("esphome.components.jbd_bms_up", _init_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["esphome.components.jbd_bms_up"] = _mod
+_spec.loader.exec_module(_mod)

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -21,6 +21,11 @@ from components.jbd_bms_ble import (  # noqa: E402
     switch as ble_switch,  # noqa: E402
     text_sensor as ble_text_sensor,
 )
+from components.jbd_bms_up_pack import (  # noqa: E402
+    binary_sensor as up_pack_binary_sensor,
+    sensor as up_pack_sensor,
+    text_sensor as up_pack_text_sensor,
+)
 
 
 class TestHubConstants:
@@ -205,3 +210,89 @@ class TestButtonConstants:
             0x05,
             [],
         )
+
+
+class TestJbdBmsUpPackSensorLists:
+    def test_cells_count(self):
+        assert len(up_pack_sensor.CELLS) == 32
+
+    def test_temperatures_count(self):
+        assert len(up_pack_sensor.TEMPERATURES) == 6
+
+    def test_sensor_defs_count(self):
+        assert len(up_pack_sensor.SENSOR_DEFS) == 31
+
+    def test_sensor_defs_original_keys(self):
+        for key in [
+            "total_voltage",
+            "current",
+            "power",
+            "charging_power",
+            "discharging_power",
+            "state_of_charge",
+            "capacity_remaining",
+            "nominal_capacity",
+            "mosfet_temperature",
+            "ambient_temperature",
+            "state_of_health",
+            "operation_status_bitmask",
+            "errors_bitmask",
+            "protect_bitmask",
+            "charging_cycles",
+            "min_cell_voltage",
+            "max_cell_voltage",
+            "min_voltage_cell",
+            "max_voltage_cell",
+            "delta_cell_voltage",
+            "average_cell_voltage",
+            "battery_strings",
+        ]:
+            assert key in up_pack_sensor.SENSOR_DEFS, f"{key} missing from SENSOR_DEFS"
+
+    def test_sensor_defs_new_keys(self):
+        assert up_pack_sensor.CONF_RATED_CAPACITY in up_pack_sensor.SENSOR_DEFS
+        assert "max_temperature" in up_pack_sensor.SENSOR_DEFS
+        assert "min_temperature" in up_pack_sensor.SENSOR_DEFS
+        assert up_pack_sensor.CONF_AVERAGE_TEMPERATURE in up_pack_sensor.SENSOR_DEFS
+        assert up_pack_sensor.CONF_CHARGE_VOLTAGE_LIMIT in up_pack_sensor.SENSOR_DEFS
+        assert up_pack_sensor.CONF_CHARGE_CURRENT_LIMIT in up_pack_sensor.SENSOR_DEFS
+        assert up_pack_sensor.CONF_DISCHARGE_VOLTAGE_LIMIT in up_pack_sensor.SENSOR_DEFS
+        assert up_pack_sensor.CONF_DISCHARGE_CURRENT_LIMIT in up_pack_sensor.SENSOR_DEFS
+        assert up_pack_sensor.CONF_BALANCING_BITMASK in up_pack_sensor.SENSOR_DEFS
+
+    def test_no_cell_or_temperature_keys_in_sensor_defs(self):
+        for key in up_pack_sensor.SENSOR_DEFS:
+            assert key not in up_pack_sensor.CELLS
+            assert key not in up_pack_sensor.TEMPERATURES
+
+
+class TestJbdBmsUpPackBinarySensorDefs:
+    def test_binary_sensor_defs_count(self):
+        assert len(up_pack_binary_sensor.BINARY_SENSOR_DEFS) == 7
+
+    def test_binary_sensor_defs_keys(self):
+        for key in [
+            up_pack_binary_sensor.CONF_BALANCING,
+            up_pack_binary_sensor.CONF_CHARGING,
+            up_pack_binary_sensor.CONF_DISCHARGING,
+            up_pack_binary_sensor.CONF_PRECHARGING,
+            up_pack_binary_sensor.CONF_HEAT,
+            up_pack_binary_sensor.CONF_FAN,
+            up_pack_binary_sensor.CONF_ONLINE_STATUS,
+        ]:
+            assert key in up_pack_binary_sensor.BINARY_SENSOR_DEFS
+
+
+class TestJbdBmsUpPackTextSensorDefs:
+    def test_text_sensor_defs_count(self):
+        assert len(up_pack_text_sensor.TEXT_SENSOR_DEFS) == 5
+
+    def test_text_sensor_defs_keys(self):
+        for key in [
+            up_pack_text_sensor.CONF_FIRMWARE_VERSION,
+            up_pack_text_sensor.CONF_OPERATION_STATUS,
+            up_pack_text_sensor.CONF_ERRORS,
+            up_pack_text_sensor.CONF_PROTECT,
+            up_pack_text_sensor.CONF_DEVICE_MODEL,
+        ]:
+            assert key in up_pack_text_sensor.TEXT_SENSOR_DEFS


### PR DESCRIPTION
## Summary

All fields below were already received in every `REG_PACK_STATUS` (0x1000–0x10A0) response but never parsed. No additional register reads or polling changes are needed.

- **`rated_capacity`** (offset 14, Ah) — factory-rated capacity, diagnostic counterpart to `nominal_capacity`
- **`max_temperature` / `min_temperature` / `average_temperature`** (offsets 50–56) — aggregate temperature values from the fixed header, complementing the per-sensor `temperature_1..6` array
- **`charge_voltage_limit` / `charge_current_limit` / `discharge_voltage_limit` / `discharge_current_limit`** (offsets 58–64) — dynamic BMS-reported CVL/CCL/DVL/DCL limits, useful for inverter integration
- **`balancing_bitmask`** + **`balancing`** binary sensor — decoded from the 2-byte balance status field after the temperature array (previously skipped as part of a silent `+ 6` offset jump)
- **`firmware_version`** text sensor — decoded from the 2-byte `major.minor` field in the same 6-byte block (also previously skipped)
- Updated `esp32-up-example.yaml` with all new sensors

## Test plan

- [ ] `rated_capacity` publishes a plausible static value (e.g. 100.00 Ah) distinct from `nominal_capacity`
- [ ] `max_temperature` / `min_temperature` match the highest/lowest values of `temperature_1..6`
- [ ] `charge_voltage_limit` / `discharge_voltage_limit` match expected CVL/DVL (e.g. 56.8 V / 40.0 V for 16S LFP)
- [ ] `balancing` binary sensor goes `true` during active cell balancing
- [ ] `firmware_version` shows a plausible version string (e.g. `1.5`)
- [ ] `device_model` (serial number string) is unaffected