### PR TITLE
Rename sensor battery_strings to cell_count (#51)

### DIFF
--- a/components/jbd_bms/__init__.py
+++ b/components/jbd_bms/__init__.py
@@ -27,6 +27,7 @@ def deprecated_renames(renames: dict[str, str]):
 
     return validator
 
+
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]
 MULTI_CONF = True

--- a/components/jbd_bms/__init__.py
+++ b/components/jbd_bms/__init__.py
@@ -11,6 +11,10 @@ _LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@syssi"]
 
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]
+MULTI_CONF = True
+
 
 def deprecated_renames(renames: dict[str, str]):
     def validator(config):
@@ -27,10 +31,6 @@ def deprecated_renames(renames: dict[str, str]):
 
     return validator
 
-
-DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]
-MULTI_CONF = True
 
 CONF_JBD_BMS_ID = "jbd_bms_id"
 CONF_RX_TIMEOUT = "rx_timeout"

--- a/components/jbd_bms/__init__.py
+++ b/components/jbd_bms/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import uart
@@ -5,7 +7,25 @@ import esphome.config_validation as cv
 from esphome.const import CONF_FLOW_CONTROL_PIN, CONF_ID
 from esphome.cpp_helpers import gpio_pin_expression
 
+_LOGGER = logging.getLogger(__name__)
+
 CODEOWNERS = ["@syssi"]
+
+
+def deprecated_renames(renames: dict[str, str]):
+    def validator(config):
+        config = config.copy()
+        for old, new in renames.items():
+            if old in config:
+                _LOGGER.warning(
+                    "'%s' is deprecated, use '%s' instead. Will be removed in a future release.",
+                    old,
+                    new,
+                )
+                config[new] = config.pop(old)
+        return config
+
+    return validator
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]

--- a/components/jbd_bms/jbd_bms.cpp
+++ b/components/jbd_bms/jbd_bms.cpp
@@ -365,7 +365,7 @@ void JbdBms::on_hardware_info_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->discharging_switch_, operation_status & JBD_MOS_DISCHARGE);
 
   // 21    2   0x04                   Cell count
-  this->publish_state_(this->battery_strings_sensor_, data[21]);
+  this->publish_state_(this->cell_count_sensor_, data[21]);
 
   // 22    3   0x03                   Temperature sensors
   // 23    2   0x0B 0x8D              Temperature 1
@@ -430,7 +430,7 @@ void JbdBms::publish_device_unavailable_() {
   this->publish_state_(operation_status_bitmask_sensor_, NAN);
   this->publish_state_(errors_bitmask_sensor_, NAN);
   this->publish_state_(balancer_status_bitmask_sensor_, NAN);
-  this->publish_state_(battery_strings_sensor_, NAN);
+  this->publish_state_(cell_count_sensor_, NAN);
   this->publish_state_(temperature_sensors_sensor_, NAN);
   this->publish_state_(software_version_sensor_, NAN);
 
@@ -469,7 +469,7 @@ void JbdBms::dump_config() {  // NOLINT(google-readability-function-size,readabi
   LOG_BINARY_SENSOR("", "Mosfet Software Lock", this->mosfet_software_lock_binary_sensor_);
 
   LOG_SENSOR("", "Total voltage", this->total_voltage_sensor_);
-  LOG_SENSOR("", "Battery strings", this->battery_strings_sensor_);
+  LOG_SENSOR("", "Cell count", this->cell_count_sensor_);
   LOG_SENSOR("", "Software version", this->software_version_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -133,8 +133,8 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void set_balancer_status_bitmask_sensor(sensor::Sensor *balancer_status_bitmask_sensor) {
     balancer_status_bitmask_sensor_ = balancer_status_bitmask_sensor;
   }
-  void set_battery_strings_sensor(sensor::Sensor *battery_strings_sensor) {
-    battery_strings_sensor_ = battery_strings_sensor;
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
+    cell_count_sensor_ = cell_count_sensor;
   }
   void set_temperature_sensors_sensor(sensor::Sensor *temperature_sensors_sensor) {
     temperature_sensors_sensor_ = temperature_sensors_sensor;
@@ -246,7 +246,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   sensor::Sensor *operation_status_bitmask_sensor_{nullptr};
   sensor::Sensor *errors_bitmask_sensor_{nullptr};
   sensor::Sensor *balancer_status_bitmask_sensor_{nullptr};
-  sensor::Sensor *battery_strings_sensor_{nullptr};
+  sensor::Sensor *cell_count_sensor_{nullptr};
   sensor::Sensor *temperature_sensors_sensor_{nullptr};
   sensor::Sensor *software_version_sensor_{nullptr};
   sensor::Sensor *short_circuit_error_count_sensor_{nullptr};

--- a/components/jbd_bms/jbd_bms.h
+++ b/components/jbd_bms/jbd_bms.h
@@ -133,9 +133,7 @@ class JbdBms : public uart::UARTDevice, public PollingComponent {
   void set_balancer_status_bitmask_sensor(sensor::Sensor *balancer_status_bitmask_sensor) {
     balancer_status_bitmask_sensor_ = balancer_status_bitmask_sensor;
   }
-  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
-    cell_count_sensor_ = cell_count_sensor;
-  }
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) { cell_count_sensor_ = cell_count_sensor; }
   void set_temperature_sensors_sensor(sensor::Sensor *temperature_sensors_sensor) {
     temperature_sensors_sensor_ = temperature_sensors_sensor;
   }

--- a/components/jbd_bms/sensor.py
+++ b/components/jbd_bms/sensor.py
@@ -22,7 +22,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JBD_BMS_ID, JBD_BMS_COMPONENT_SCHEMA
+from . import CONF_JBD_BMS_ID, JBD_BMS_COMPONENT_SCHEMA, deprecated_renames
 
 DEPENDENCIES = ["jbd_bms"]
 
@@ -46,7 +46,7 @@ CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
 CONF_OPERATION_STATUS_BITMASK = "operation_status_bitmask"
 CONF_ERRORS_BITMASK = "errors_bitmask"
 CONF_BALANCER_STATUS_BITMASK = "balancer_status_bitmask"
-CONF_BATTERY_STRINGS = "battery_strings"
+CONF_CELL_COUNT = "cell_count"
 CONF_SOFTWARE_VERSION = "software_version"
 CONF_SHORT_CIRCUIT_ERROR_COUNT = "short_circuit_error_count"
 CONF_CHARGE_OVERCURRENT_ERROR_COUNT = "charge_overcurrent_error_count"
@@ -61,7 +61,7 @@ CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT = "battery_overvoltage_error_count"
 CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT = "battery_undervoltage_error_count"
 
 ICON_CURRENT_DC = "mdi:current-dc"
-ICON_BATTERY_STRINGS = "mdi:car-battery"
+ICON_CELL_COUNT = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_NOMINAL_CAPACITY = "mdi:battery-50"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
@@ -211,9 +211,9 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
-    CONF_BATTERY_STRINGS: {
+    CONF_CELL_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
-        "icon": ICON_BATTERY_STRINGS,
+        "icon": ICON_CELL_COUNT,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
@@ -328,7 +328,12 @@ _TEMPERATURE_SCHEMA = sensor.sensor_schema(
     state_class=STATE_CLASS_MEASUREMENT,
 )
 
-CONFIG_SCHEMA = (
+_RENAMED_SENSORS = {
+    "battery_strings": "cell_count",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_SENSORS),
     JBD_BMS_COMPONENT_SCHEMA.extend(
         {
             cv.Optional(key): sensor.sensor_schema(**kwargs)
@@ -336,7 +341,7 @@ CONFIG_SCHEMA = (
         }
     )
     .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
-    .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES})
+    .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES}),
 )
 
 

--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -24,6 +24,8 @@ def deprecated_renames(renames: dict[str, str]):
         return config
 
     return validator
+
+
 CONF_NOTIFY_CHARACTERISTIC_UUID = "notify_characteristic_uuid"
 CONF_CONTROL_CHARACTERISTIC_UUID = "control_characteristic_uuid"
 

--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -7,7 +7,10 @@ from esphome.const import CONF_ID, CONF_PASSWORD, CONF_SERVICE_UUID
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_AUTH_TIMEOUT = "auth_timeout"
+CODEOWNERS = ["@syssi"]
+DEPENDENCIES = ["ble_client"]
+AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]
+MULTI_CONF = True
 
 
 def deprecated_renames(renames: dict[str, str]):
@@ -26,15 +29,10 @@ def deprecated_renames(renames: dict[str, str]):
     return validator
 
 
+CONF_JBD_BMS_BLE_ID = "jbd_bms_ble_id"
+CONF_AUTH_TIMEOUT = "auth_timeout"
 CONF_NOTIFY_CHARACTERISTIC_UUID = "notify_characteristic_uuid"
 CONF_CONTROL_CHARACTERISTIC_UUID = "control_characteristic_uuid"
-
-CODEOWNERS = ["@syssi"]
-DEPENDENCIES = ["ble_client"]
-AUTO_LOAD = ["binary_sensor", "button", "select", "sensor", "switch", "text_sensor"]
-MULTI_CONF = True
-
-CONF_JBD_BMS_BLE_ID = "jbd_bms_ble_id"
 
 jbd_bms_ble_ns = cg.esphome_ns.namespace("jbd_bms_ble")
 JbdBmsBle = jbd_bms_ble_ns.class_(

--- a/components/jbd_bms_ble/__init__.py
+++ b/components/jbd_bms_ble/__init__.py
@@ -1,9 +1,29 @@
+import logging
+
 import esphome.codegen as cg
 from esphome.components import ble_client
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PASSWORD, CONF_SERVICE_UUID
 
+_LOGGER = logging.getLogger(__name__)
+
 CONF_AUTH_TIMEOUT = "auth_timeout"
+
+
+def deprecated_renames(renames: dict[str, str]):
+    def validator(config):
+        config = config.copy()
+        for old, new in renames.items():
+            if old in config:
+                _LOGGER.warning(
+                    "'%s' is deprecated, use '%s' instead. Will be removed in a future release.",
+                    old,
+                    new,
+                )
+                config[new] = config.pop(old)
+        return config
+
+    return validator
 CONF_NOTIFY_CHARACTERISTIC_UUID = "notify_characteristic_uuid"
 CONF_CONTROL_CHARACTERISTIC_UUID = "control_characteristic_uuid"
 

--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -600,7 +600,7 @@ void JbdBmsBle::on_hardware_info_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->discharging_switch_, operation_status & JBD_MOS_DISCHARGE);
 
   // 21    2   0x04                   Cell count
-  this->publish_state_(this->battery_strings_sensor_, data[21]);
+  this->publish_state_(this->cell_count_sensor_, data[21]);
 
   // 22    3   0x03                   Temperature sensors
   // 23    2   0x0B 0x8D              Temperature 1
@@ -692,7 +692,7 @@ void JbdBmsBle::publish_device_unavailable_() {
   this->publish_state_(operation_status_bitmask_sensor_, NAN);
   this->publish_state_(errors_bitmask_sensor_, NAN);
   this->publish_state_(balancer_status_bitmask_sensor_, NAN);
-  this->publish_state_(battery_strings_sensor_, NAN);
+  this->publish_state_(cell_count_sensor_, NAN);
   this->publish_state_(temperature_sensors_sensor_, NAN);
   this->publish_state_(software_version_sensor_, NAN);
 
@@ -732,7 +732,7 @@ void JbdBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   LOG_BINARY_SENSOR("", "Mosfet Software Lock", this->mosfet_software_lock_binary_sensor_);
 
   LOG_SENSOR("", "Total voltage", this->total_voltage_sensor_);
-  LOG_SENSOR("", "Battery strings", this->battery_strings_sensor_);
+  LOG_SENSOR("", "Cell count", this->cell_count_sensor_);
   LOG_SENSOR("", "Software version", this->software_version_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -145,9 +145,7 @@ class JbdBmsBle :
   void set_balancer_status_bitmask_sensor(sensor::Sensor *balancer_status_bitmask_sensor) {
     balancer_status_bitmask_sensor_ = balancer_status_bitmask_sensor;
   }
-  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
-    cell_count_sensor_ = cell_count_sensor;
-  }
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) { cell_count_sensor_ = cell_count_sensor; }
   void set_temperature_sensors_sensor(sensor::Sensor *temperature_sensors_sensor) {
     temperature_sensors_sensor_ = temperature_sensors_sensor;
   }

--- a/components/jbd_bms_ble/jbd_bms_ble.h
+++ b/components/jbd_bms_ble/jbd_bms_ble.h
@@ -145,8 +145,8 @@ class JbdBmsBle :
   void set_balancer_status_bitmask_sensor(sensor::Sensor *balancer_status_bitmask_sensor) {
     balancer_status_bitmask_sensor_ = balancer_status_bitmask_sensor;
   }
-  void set_battery_strings_sensor(sensor::Sensor *battery_strings_sensor) {
-    battery_strings_sensor_ = battery_strings_sensor;
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
+    cell_count_sensor_ = cell_count_sensor;
   }
   void set_temperature_sensors_sensor(sensor::Sensor *temperature_sensors_sensor) {
     temperature_sensors_sensor_ = temperature_sensors_sensor;
@@ -266,7 +266,7 @@ class JbdBmsBle :
   sensor::Sensor *operation_status_bitmask_sensor_{nullptr};
   sensor::Sensor *errors_bitmask_sensor_{nullptr};
   sensor::Sensor *balancer_status_bitmask_sensor_{nullptr};
-  sensor::Sensor *battery_strings_sensor_{nullptr};
+  sensor::Sensor *cell_count_sensor_{nullptr};
   sensor::Sensor *temperature_sensors_sensor_{nullptr};
   sensor::Sensor *software_version_sensor_{nullptr};
   sensor::Sensor *short_circuit_error_count_sensor_{nullptr};

--- a/components/jbd_bms_ble/sensor.py
+++ b/components/jbd_bms_ble/sensor.py
@@ -22,7 +22,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JBD_BMS_BLE_ID, JBD_BMS_BLE_COMPONENT_SCHEMA
+from . import CONF_JBD_BMS_BLE_ID, JBD_BMS_BLE_COMPONENT_SCHEMA, deprecated_renames
 
 DEPENDENCIES = ["jbd_bms_ble"]
 
@@ -46,7 +46,7 @@ CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
 CONF_OPERATION_STATUS_BITMASK = "operation_status_bitmask"
 CONF_ERRORS_BITMASK = "errors_bitmask"
 CONF_BALANCER_STATUS_BITMASK = "balancer_status_bitmask"
-CONF_BATTERY_STRINGS = "battery_strings"
+CONF_CELL_COUNT = "cell_count"
 CONF_SOFTWARE_VERSION = "software_version"
 CONF_SHORT_CIRCUIT_ERROR_COUNT = "short_circuit_error_count"
 CONF_CHARGE_OVERCURRENT_ERROR_COUNT = "charge_overcurrent_error_count"
@@ -61,7 +61,7 @@ CONF_BATTERY_OVERVOLTAGE_ERROR_COUNT = "battery_overvoltage_error_count"
 CONF_BATTERY_UNDERVOLTAGE_ERROR_COUNT = "battery_undervoltage_error_count"
 
 ICON_CURRENT_DC = "mdi:current-dc"
-ICON_BATTERY_STRINGS = "mdi:car-battery"
+ICON_CELL_COUNT = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_NOMINAL_CAPACITY = "mdi:battery-50"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
@@ -208,9 +208,9 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_EMPTY,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
-    CONF_BATTERY_STRINGS: {
+    CONF_CELL_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
-        "icon": ICON_BATTERY_STRINGS,
+        "icon": ICON_CELL_COUNT,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
@@ -324,7 +324,12 @@ _TEMPERATURE_SCHEMA = sensor.sensor_schema(
     state_class=STATE_CLASS_MEASUREMENT,
 )
 
-CONFIG_SCHEMA = (
+_RENAMED_SENSORS = {
+    "battery_strings": "cell_count",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_SENSORS),
     JBD_BMS_BLE_COMPONENT_SCHEMA.extend(
         {
             cv.Optional(key): sensor.sensor_schema(**kwargs)
@@ -333,7 +338,7 @@ CONFIG_SCHEMA = (
     )
     .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
     .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES})
-    .extend(JBD_BMS_BLE_COMPONENT_SCHEMA)
+    .extend(JBD_BMS_BLE_COMPONENT_SCHEMA),
 )
 
 

--- a/components/jbd_bms_up_pack/__init__.py
+++ b/components/jbd_bms_up_pack/__init__.py
@@ -17,6 +17,7 @@ AUTO_LOAD = [
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
+
 def deprecated_renames(renames: dict[str, str]):
     def validator(config):
         config = config.copy()

--- a/components/jbd_bms_up_pack/__init__.py
+++ b/components/jbd_bms_up_pack/__init__.py
@@ -1,7 +1,11 @@
+import logging
+
 import esphome.codegen as cg
 from esphome.components import jbd_bms_up  # pylint: disable=no-name-in-module
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+
+_LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = [
     "jbd_bms_up",
@@ -12,6 +16,22 @@ AUTO_LOAD = [
 ]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
+
+def deprecated_renames(renames: dict[str, str]):
+    def validator(config):
+        config = config.copy()
+        for old, new in renames.items():
+            if old in config:
+                _LOGGER.warning(
+                    "'%s' is deprecated, use '%s' instead. Will be removed in a future release.",
+                    old,
+                    new,
+                )
+                config[new] = config.pop(old)
+        return config
+
+    return validator
+
 
 CONF_JBD_BMS_UP_PACK_ID = "jbd_bms_up_pack_id"
 

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.cpp
@@ -182,7 +182,7 @@ void JbdBmsUpPack::on_pack_status_(const std::vector<uint8_t> &data) {
   }
 
   uint16_t cell_count = jbd_get_16bit(66);
-  this->publish_state_(battery_strings_sensor_, (float) cell_count);
+  this->publish_state_(cell_count_sensor_, (float) cell_count);
 
   size_t offset = 68;
   uint8_t cell_sensor_count = std::min((uint16_t) 32, cell_count);
@@ -270,7 +270,7 @@ void JbdBmsUpPack::dump_config() {
   LOG_SENSOR("", "Max Voltage Cell", this->max_voltage_cell_sensor_);
   LOG_SENSOR("", "Delta Cell Voltage", this->delta_cell_voltage_sensor_);
   LOG_SENSOR("", "Average Cell Voltage", this->average_cell_voltage_sensor_);
-  LOG_SENSOR("", "Battery Strings", this->battery_strings_sensor_);
+  LOG_SENSOR("", "Cell count", this->cell_count_sensor_);
   LOG_SENSOR("", "Charge Voltage Limit", this->charge_voltage_limit_sensor_);
   LOG_SENSOR("", "Charge Current Limit", this->charge_current_limit_sensor_);
   LOG_SENSOR("", "Discharge Voltage Limit", this->discharge_voltage_limit_sensor_);

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.h
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.h
@@ -75,9 +75,7 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
   void set_average_cell_voltage_sensor(sensor::Sensor *average_cell_voltage_sensor) {
     average_cell_voltage_sensor_ = average_cell_voltage_sensor;
   }
-  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
-    cell_count_sensor_ = cell_count_sensor;
-  }
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) { cell_count_sensor_ = cell_count_sensor; }
 
   void set_cell_voltage_sensor(uint8_t cell, sensor::Sensor *sensor) { cell_voltage_sensors_[cell] = sensor; }
   void set_temperature_sensor(uint8_t index, sensor::Sensor *sensor) { temperature_sensors_[index] = sensor; }

--- a/components/jbd_bms_up_pack/jbd_bms_up_pack.h
+++ b/components/jbd_bms_up_pack/jbd_bms_up_pack.h
@@ -75,8 +75,8 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
   void set_average_cell_voltage_sensor(sensor::Sensor *average_cell_voltage_sensor) {
     average_cell_voltage_sensor_ = average_cell_voltage_sensor;
   }
-  void set_battery_strings_sensor(sensor::Sensor *battery_strings_sensor) {
-    battery_strings_sensor_ = battery_strings_sensor;
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) {
+    cell_count_sensor_ = cell_count_sensor;
   }
 
   void set_cell_voltage_sensor(uint8_t cell, sensor::Sensor *sensor) { cell_voltage_sensors_[cell] = sensor; }
@@ -181,7 +181,7 @@ class JbdBmsUpPack : public PollingComponent, public jbd_bms_up::JbdBmsUpDevice 
   sensor::Sensor *max_voltage_cell_sensor_{nullptr};
   sensor::Sensor *delta_cell_voltage_sensor_{nullptr};
   sensor::Sensor *average_cell_voltage_sensor_{nullptr};
-  sensor::Sensor *battery_strings_sensor_{nullptr};
+  sensor::Sensor *cell_count_sensor_{nullptr};
   sensor::Sensor *charge_voltage_limit_sensor_{nullptr};
   sensor::Sensor *charge_current_limit_sensor_{nullptr};
   sensor::Sensor *discharge_voltage_limit_sensor_{nullptr};

--- a/components/jbd_bms_up_pack/sensor.py
+++ b/components/jbd_bms_up_pack/sensor.py
@@ -24,7 +24,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JBD_BMS_UP_PACK_ID, JBD_BMS_UP_PACK_COMPONENT_SCHEMA
+from . import CONF_JBD_BMS_UP_PACK_ID, JBD_BMS_UP_PACK_COMPONENT_SCHEMA, deprecated_renames
 
 DEPENDENCIES = ["jbd_bms_up_pack"]
 
@@ -51,7 +51,7 @@ CONF_MIN_VOLTAGE_CELL = "min_voltage_cell"
 CONF_MAX_VOLTAGE_CELL = "max_voltage_cell"
 CONF_DELTA_CELL_VOLTAGE = "delta_cell_voltage"
 CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
-CONF_BATTERY_STRINGS = "battery_strings"
+CONF_CELL_COUNT = "cell_count"
 CONF_CHARGE_VOLTAGE_LIMIT = "charge_voltage_limit"
 CONF_CHARGE_CURRENT_LIMIT = "charge_current_limit"
 CONF_DISCHARGE_VOLTAGE_LIMIT = "discharge_voltage_limit"
@@ -69,7 +69,7 @@ ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 ICON_OPERATION_STATUS_BITMASK = "mdi:heart-pulse"
 ICON_ERRORS_BITMASK = "mdi:alert-circle-outline"
 ICON_PROTECT_BITMASK = "mdi:shield-alert-outline"
-ICON_BATTERY_STRINGS = "mdi:car-battery"
+ICON_CELL_COUNT = "mdi:car-battery"
 ICON_BALANCING_BITMASK = "mdi:seesaw"
 
 UNIT_AMPERE_HOURS = "Ah"
@@ -256,9 +256,9 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_VOLTAGE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
-    CONF_BATTERY_STRINGS: {
+    CONF_CELL_COUNT: {
         "unit_of_measurement": UNIT_EMPTY,
-        "icon": ICON_BATTERY_STRINGS,
+        "icon": ICON_CELL_COUNT,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
@@ -306,7 +306,12 @@ SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = (
+_RENAMED_SENSORS = {
+    "battery_strings": "cell_count",
+}
+
+CONFIG_SCHEMA = cv.All(
+    deprecated_renames(_RENAMED_SENSORS),
     JBD_BMS_UP_PACK_COMPONENT_SCHEMA.extend(
         {
             cv.Optional(key): sensor.sensor_schema(**kwargs)
@@ -336,7 +341,7 @@ CONFIG_SCHEMA = (
             )
             for temp in TEMPERATURES
         }
-    )
+    ),
 )
 
 

--- a/components/jbd_bms_up_pack/sensor.py
+++ b/components/jbd_bms_up_pack/sensor.py
@@ -24,7 +24,11 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_JBD_BMS_UP_PACK_ID, JBD_BMS_UP_PACK_COMPONENT_SCHEMA, deprecated_renames
+from . import (
+    CONF_JBD_BMS_UP_PACK_ID,
+    JBD_BMS_UP_PACK_COMPONENT_SCHEMA,
+    deprecated_renames,
+)
 
 DEPENDENCIES = ["jbd_bms_up_pack"]
 

--- a/esp32-ble-dh04sc02-example.yaml
+++ b/esp32-ble-dh04sc02-example.yaml
@@ -144,7 +144,7 @@ binary_sensor:
 sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
-    battery_strings:
+    cell_count:
       name: "battery strings"
     current:
       name: "current"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -138,7 +138,7 @@ binary_sensor:
 sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
-    battery_strings:
+    cell_count:
       name: "battery strings"
     current:
       name: "current"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -133,7 +133,7 @@ binary_sensor:
 sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
-    battery_strings:
+    cell_count:
       name: "battery strings"
     current:
       name: "current"

--- a/esp32-up-example-multiple-devices.yaml
+++ b/esp32-up-example-multiple-devices.yaml
@@ -162,7 +162,7 @@ sensor:
     average_cell_voltage:
       name: "${bms0} average cell voltage"
       device_id: device0
-    battery_strings:
+    cell_count:
       name: "${bms0} battery strings"
       device_id: device0
     operation_status_bitmask:
@@ -344,7 +344,7 @@ sensor:
     average_cell_voltage:
       name: "${bms1} average cell voltage"
       device_id: device1
-    battery_strings:
+    cell_count:
       name: "${bms1} battery strings"
       device_id: device1
     operation_status_bitmask:

--- a/esp32-up-example.yaml
+++ b/esp32-up-example.yaml
@@ -127,7 +127,7 @@ sensor:
       name: "${name} delta cell voltage"
     average_cell_voltage:
       name: "${name} average cell voltage"
-    battery_strings:
+    cell_count:
       name: "${name} battery strings"
     operation_status_bitmask:
       name: "${name} operation status bitmask"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -131,7 +131,7 @@ binary_sensor:
 sensor:
   - platform: jbd_bms
     jbd_bms_id: bms0
-    battery_strings:
+    cell_count:
       name: "battery strings"
     current:
       name: "current"

--- a/tests/components/jbd_bms/frames.h
+++ b/tests/components/jbd_bms/frames.h
@@ -11,7 +11,7 @@ namespace esphome::jbd_bms::testing {
 //   charging_cycles: 0             soc: 100 %
 //   balancer_status_bitmask: 0     errors_bitmask: 0
 //   software_version: 8.0          operation_status: 0x03 → "Charging, Discharging"
-//   battery_strings: 4             temperature_sensors: 3
+//   cell_count: 4             temperature_sensors: 3
 //   temperatures[0]: 22.4°C  [1]: 22.3°C  [2]: 21.7°C
 static const std::vector<uint8_t> HWINFO_FRAME = {
     0x06, 0x18, 0x00, 0x00, 0x01, 0xF2, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
@@ -53,7 +53,7 @@ static const std::vector<uint8_t> ERRCOUNT_FRAME = {
 //   charging_cycles: 8             soc: 100 %
 //   balancer_status_bitmask: 0     errors_bitmask: 0x0001 → cell_overvoltage_protection
 //   software_version: 8.0          operation_status: 0x02 → "Discharging"
-//   battery_strings: 4             temperature_sensors: 3
+//   cell_count: 4             temperature_sensors: 3
 //   temperatures[0]: 21.5°C  [1]: 20.9°C  [2]: 20.4°C
 static const std::vector<uint8_t> HWINFO_FRAME_CELL_OVERVOLTAGE = {
     0x05, 0x94, 0x00, 0x00, 0x6D, 0x60, 0x6D, 0x60, 0x00, 0x08, 0x2C, 0x7C, 0x00, 0x00, 0x00,
@@ -74,7 +74,7 @@ static const std::vector<uint8_t> HWINFO_FRAME_ALL_PROTECTIONS = {
 //   charging_cycles: 0             soc: 99 %
 //   balancer_status_bitmask: 0     errors_bitmask: 0x1000 → mosfet_software_lock
 //   software_version: 8.0          operation_status: 0x02 → "Discharging"
-//   battery_strings: 4             temperature_sensors: 3
+//   cell_count: 4             temperature_sensors: 3
 //   temperatures[0]: 24.5°C  [1]: 24.2°C  [2]: 23.7°C
 static const std::vector<uint8_t> HWINFO_FRAME_MOSFET_SOFTWARE_LOCK = {
     0x06, 0x0B, 0x00, 0x00, 0x01, 0xED, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
@@ -82,7 +82,7 @@ static const std::vector<uint8_t> HWINFO_FRAME_MOSFET_SOFTWARE_LOCK = {
 };
 
 // Synthetic frame: cells 1 and 3 balancing (4S pack). Decoded key values:
-//   battery_strings: 4
+//   cell_count: 4
 //   balancer_status_bitmask: 0x0000000A → bit3=cell1, bit1=cell3
 //   errors_bitmask: 0
 static const std::vector<uint8_t> HWINFO_FRAME_BALANCING_CELLS_1_3 = {

--- a/tests/components/jbd_bms/jbd_bms_test.cpp
+++ b/tests/components/jbd_bms/jbd_bms_test.cpp
@@ -79,7 +79,7 @@ TEST(JbdBmsHwInfoTest, SoftwareVersion) {
 TEST(JbdBmsHwInfoTest, BatteryStringsAndTempSensors) {
   TestableJbdBms bms;
   sensor::Sensor strings, temp_sensors;
-  bms.set_battery_strings_sensor(&strings);
+  bms.set_cell_count_sensor(&strings);
   bms.set_temperature_sensors_sensor(&temp_sensors);
 
   bms.on_jbd_bms_data(0x03, HWINFO_FRAME);

--- a/tests/components/jbd_bms_ble/frames.h
+++ b/tests/components/jbd_bms_ble/frames.h
@@ -11,7 +11,7 @@ namespace esphome::jbd_bms_ble::testing {
 //   charging_cycles: 0             soc: 100 %
 //   balancer_status_bitmask: 0     errors_bitmask: 0
 //   software_version: 8.0          operation_status: 0x03 → "Charging, Discharging"
-//   battery_strings: 4             temperature_sensors: 3
+//   cell_count: 4             temperature_sensors: 3
 //   temperatures[0]: 22.4°C  [1]: 22.3°C  [2]: 21.7°C
 static const std::vector<uint8_t> HWINFO_FRAME = {
     0x06, 0x18, 0x00, 0x00, 0x01, 0xF2, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
@@ -53,7 +53,7 @@ static const std::vector<uint8_t> ERRCOUNT_FRAME = {
 //   charging_cycles: 8             soc: 100 %
 //   balancer_status_bitmask: 0     errors_bitmask: 0x0001 → cell_overvoltage_protection
 //   software_version: 8.0          operation_status: 0x02 → "Discharging"
-//   battery_strings: 4             temperature_sensors: 3
+//   cell_count: 4             temperature_sensors: 3
 //   temperatures[0]: 21.5°C  [1]: 20.9°C  [2]: 20.4°C
 static const std::vector<uint8_t> HWINFO_FRAME_CELL_OVERVOLTAGE = {
     0x05, 0x94, 0x00, 0x00, 0x6D, 0x60, 0x6D, 0x60, 0x00, 0x08, 0x2C, 0x7C, 0x00, 0x00, 0x00,
@@ -74,7 +74,7 @@ static const std::vector<uint8_t> HWINFO_FRAME_ALL_PROTECTIONS = {
 //   charging_cycles: 0             soc: 99 %
 //   balancer_status_bitmask: 0     errors_bitmask: 0x1000 → mosfet_software_lock
 //   software_version: 8.0          operation_status: 0x02 → "Discharging"
-//   battery_strings: 4             temperature_sensors: 3
+//   cell_count: 4             temperature_sensors: 3
 //   temperatures[0]: 24.5°C  [1]: 24.2°C  [2]: 23.7°C
 static const std::vector<uint8_t> HWINFO_FRAME_MOSFET_SOFTWARE_LOCK = {
     0x06, 0x0B, 0x00, 0x00, 0x01, 0xED, 0x01, 0xF4, 0x00, 0x00, 0x2C, 0x7C, 0x00, 0x00, 0x00,
@@ -82,7 +82,7 @@ static const std::vector<uint8_t> HWINFO_FRAME_MOSFET_SOFTWARE_LOCK = {
 };
 
 // Synthetic frame: cells 1 and 3 balancing (4S pack). Decoded key values:
-//   battery_strings: 4
+//   cell_count: 4
 //   balancer_status_bitmask: 0x0000000A → bit3=cell1, bit1=cell3
 //   errors_bitmask: 0
 static const std::vector<uint8_t> HWINFO_FRAME_BALANCING_CELLS_1_3 = {

--- a/tests/components/jbd_bms_ble/jbd_bms_ble_test.cpp
+++ b/tests/components/jbd_bms_ble/jbd_bms_ble_test.cpp
@@ -79,7 +79,7 @@ TEST(JbdBmsBleHwInfoTest, SoftwareVersion) {
 TEST(JbdBmsBleHwInfoTest, BatteryStringsAndTempSensors) {
   TestableJbdBmsBle bms;
   sensor::Sensor strings, temp_sensors;
-  bms.set_battery_strings_sensor(&strings);
+  bms.set_cell_count_sensor(&strings);
   bms.set_temperature_sensors_sensor(&temp_sensors);
 
   bms.on_jbd_bms_data(0x03, HWINFO_FRAME);

--- a/tests/components/jbd_bms_up/frames.h
+++ b/tests/components/jbd_bms_up/frames.h
@@ -23,7 +23,7 @@ namespace esphome::jbd_bms_up::testing {
 //   max_voltage_cell:      3 (1-idx)  max_cell_voltage:      3.331 V
 //   min_voltage_cell:      8 (1-idx)  min_cell_voltage:      3.317 V
 //   avg_cell_voltage:      3.323 V    delta_cell_voltage:    0.014 V
-//   battery_strings:       16         temp[0..3]: 20.9, 20.4, 21.0, 21.2 °C
+//   cell_count:       16         temp[0..3]: 20.9, 20.4, 21.0, 21.2 °C
 //   device_model:          "JBD48100000"
 
 // clang-format off
@@ -89,7 +89,7 @@ static const std::vector<uint8_t> PACK_STATUS_FRAME(PACK_STATUS_RESPONSE.begin()
 //   max_voltage_cell:      4 (1-idx)  max_cell_voltage:      3.329 V
 //   min_voltage_cell:      1 (1-idx)  min_cell_voltage:      3.322 V
 //   avg_cell_voltage:      3.325 V    delta_cell_voltage:    0.007 V
-//   battery_strings:       16         temp[0..3]: 21.4, 21.3, 22.0, 21.8 °C
+//   cell_count:       16         temp[0..3]: 21.4, 21.3, 22.0, 21.8 °C
 //   device_model:          "JBD48100000"
 
 // clang-format off

--- a/tests/components/jbd_bms_up_pack/frames.h
+++ b/tests/components/jbd_bms_up_pack/frames.h
@@ -23,7 +23,7 @@ namespace esphome::jbd_bms_up::testing {
 //   max_voltage_cell:      3 (1-idx)  max_cell_voltage:      3.331 V
 //   min_voltage_cell:      8 (1-idx)  min_cell_voltage:      3.317 V
 //   avg_cell_voltage:      3.323 V    delta_cell_voltage:    0.014 V
-//   battery_strings:       16         temp[0..3]: 20.9, 20.4, 21.0, 21.2 °C
+//   cell_count:       16         temp[0..3]: 20.9, 20.4, 21.0, 21.2 °C
 //   device_model:          "JBD48100000"
 
 // clang-format off
@@ -89,7 +89,7 @@ static const std::vector<uint8_t> PACK_STATUS_FRAME(PACK_STATUS_RESPONSE.begin()
 //   max_voltage_cell:      4 (1-idx)  max_cell_voltage:      3.329 V
 //   min_voltage_cell:      1 (1-idx)  min_cell_voltage:      3.322 V
 //   avg_cell_voltage:      3.325 V    delta_cell_voltage:    0.007 V
-//   battery_strings:       16         temp[0..3]: 21.4, 21.3, 22.0, 21.8 °C
+//   cell_count:       16         temp[0..3]: 21.4, 21.3, 22.0, 21.8 °C
 //   device_model:          "JBD48100000"
 
 // clang-format off

--- a/tests/components/jbd_bms_up_pack/pack_status_test.cpp
+++ b/tests/components/jbd_bms_up_pack/pack_status_test.cpp
@@ -199,7 +199,7 @@ TEST(PackStatusTest, CellVoltageStats) {
 TEST(PackStatusTest, BatteryStrings) {
   TestableJbdBmsUpPack pack;
   sensor::Sensor strings;
-  pack.set_battery_strings_sensor(&strings);
+  pack.set_cell_count_sensor(&strings);
   pack.on_pack_status_(PACK_STATUS_FRAME);
   EXPECT_FLOAT_EQ(strings.state, 16.0f);
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,9 @@ sys.path.insert(0, project_root)
 # jbd_bms_up is a custom component, not part of the installed esphome package.
 # Inject it so that jbd_bms_up_pack can resolve "from esphome.components import jbd_bms_up".
 _init_path = os.path.join(project_root, "components", "jbd_bms_up", "__init__.py")
-_spec = importlib.util.spec_from_file_location("esphome.components.jbd_bms_up", _init_path)
+_spec = importlib.util.spec_from_file_location(
+    "esphome.components.jbd_bms_up", _init_path
+)
 _mod = importlib.util.module_from_spec(_spec)
 sys.modules["esphome.components.jbd_bms_up"] = _mod
 _spec.loader.exec_module(_mod)

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -245,7 +245,7 @@ class TestJbdBmsUpPackSensorLists:
             "max_voltage_cell",
             "delta_cell_voltage",
             "average_cell_voltage",
-            "battery_strings",
+            "cell_count",
         ]:
             assert key in up_pack_sensor.SENSOR_DEFS, f"{key} missing from SENSOR_DEFS"
 


### PR DESCRIPTION
## Summary

- Renames the `battery_strings` sensor to `cell_count` across all three components (`jbd_bms`, `jbd_bms_ble`, `jbd_bms_up_pack`)
- Adds a `deprecated_renames` compat layer (modelled after `esphome-jk-bms`) to each component's `__init__.py`
- YAML configs using `battery_strings` continue to work but emit a deprecation warning: `'battery_strings' is deprecated, use 'cell_count' instead. Will be removed in a future release.`
- Updates all example YAML files and C++ log labels to use the new name

## Test plan

- [ ] YAML with `cell_count:` compiles without warnings
- [ ] YAML with `battery_strings:` compiles with the deprecation warning and still works
- [ ] Sensor value is published correctly on device