### PR TITLE
Auto-poll hardware version and error counts; expand multi-device example config

### DIFF
--- a/components/jbd_bms_ble/jbd_bms_ble.cpp
+++ b/components/jbd_bms_ble/jbd_bms_ble.cpp
@@ -442,9 +442,11 @@ void JbdBmsBle::on_jbd_bms_data(const uint8_t &function, const std::vector<uint8
       break;
     case JBD_CMD_CELLINFO:
       this->on_cell_info_data_(data);
+      this->send_command(JBD_CMD_READ, JBD_CMD_HWVER);
       break;
     case JBD_CMD_HWVER:
       this->on_hardware_version_data_(data);
+      this->send_command(JBD_CMD_READ, JBD_CMD_ERROR_COUNTS);
       break;
     case JBD_CMD_ERROR_COUNTS:
       this->on_error_counts_data_(data);

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -220,41 +220,237 @@ binary_sensor:
 sensor:
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms0
+    total_voltage:
+      name: "total voltage"
+      device_id: device0
+    current:
+      name: "current"
+      device_id: device0
     power:
       name: "power"
+      device_id: device0
+    charging_power:
+      name: "charging power"
+      device_id: device0
+    discharging_power:
+      name: "discharging power"
       device_id: device0
     state_of_charge:
       name: "state of charge"
       device_id: device0
-    total_voltage:
-      name: "total voltage"
+    nominal_capacity:
+      name: "nominal capacity"
       device_id: device0
-    average_cell_voltage:
-      name: "average cell voltage"
+    capacity_remaining:
+      name: "capacity remaining"
+      device_id: device0
+    charging_cycles:
+      name: "charging cycles"
+      device_id: device0
+    min_cell_voltage:
+      name: "min cell voltage"
+      device_id: device0
+    max_cell_voltage:
+      name: "max cell voltage"
+      device_id: device0
+    min_voltage_cell:
+      name: "min voltage cell"
+      device_id: device0
+    max_voltage_cell:
+      name: "max voltage cell"
       device_id: device0
     delta_cell_voltage:
       name: "delta cell voltage"
       device_id: device0
-    # ...
+    average_cell_voltage:
+      name: "average cell voltage"
+      device_id: device0
+    cell_count:
+      name: "cell count"
+      device_id: device0
+    software_version:
+      name: "software version"
+      device_id: device0
+    operation_status_bitmask:
+      name: "operation status bitmask"
+      device_id: device0
+    errors_bitmask:
+      name: "errors bitmask"
+      device_id: device0
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
+      device_id: device0
+    short_circuit_error_count:
+      name: "short circuit error count"
+      device_id: device0
+    charge_overcurrent_error_count:
+      name: "charge overcurrent error count"
+      device_id: device0
+    discharge_overcurrent_error_count:
+      name: "discharge overcurrent error count"
+      device_id: device0
+    cell_overvoltage_error_count:
+      name: "cell overvoltage error count"
+      device_id: device0
+    cell_undervoltage_error_count:
+      name: "cell undervoltage error count"
+      device_id: device0
+    charge_overtemperature_error_count:
+      name: "charge overtemperature error count"
+      device_id: device0
+    charge_undertemperature_error_count:
+      name: "charge undertemperature error count"
+      device_id: device0
+    discharge_overtemperature_error_count:
+      name: "discharge overtemperature error count"
+      device_id: device0
+    discharge_undertemperature_error_count:
+      name: "discharge undertemperature error count"
+      device_id: device0
+    battery_overvoltage_error_count:
+      name: "battery overvoltage error count"
+      device_id: device0
+    battery_undervoltage_error_count:
+      name: "battery undervoltage error count"
+      device_id: device0
+    cell_voltage_1:
+      name: "cell voltage 1"
+      device_id: device0
+    cell_voltage_2:
+      name: "cell voltage 2"
+      device_id: device0
+    cell_voltage_3:
+      name: "cell voltage 3"
+      device_id: device0
+    cell_voltage_4:
+      name: "cell voltage 4"
+      device_id: device0
+    temperature_1:
+      name: "temperature 1"
+      device_id: device0
+    temperature_2:
+      name: "temperature 2"
+      device_id: device0
+    temperature_3:
+      name: "temperature 3"
+      device_id: device0
 
   - platform: jbd_bms_ble
     jbd_bms_ble_id: bms1
+    total_voltage:
+      name: "total voltage"
+      device_id: device1
+    current:
+      name: "current"
+      device_id: device1
     power:
       name: "power"
+      device_id: device1
+    charging_power:
+      name: "charging power"
+      device_id: device1
+    discharging_power:
+      name: "discharging power"
       device_id: device1
     state_of_charge:
       name: "state of charge"
       device_id: device1
-    total_voltage:
-      name: "total voltage"
+    nominal_capacity:
+      name: "nominal capacity"
       device_id: device1
-    average_cell_voltage:
-      name: "average cell voltage"
+    capacity_remaining:
+      name: "capacity remaining"
+      device_id: device1
+    charging_cycles:
+      name: "charging cycles"
+      device_id: device1
+    min_cell_voltage:
+      name: "min cell voltage"
+      device_id: device1
+    max_cell_voltage:
+      name: "max cell voltage"
+      device_id: device1
+    min_voltage_cell:
+      name: "min voltage cell"
+      device_id: device1
+    max_voltage_cell:
+      name: "max voltage cell"
       device_id: device1
     delta_cell_voltage:
       name: "delta cell voltage"
       device_id: device1
-    # ...
+    average_cell_voltage:
+      name: "average cell voltage"
+      device_id: device1
+    cell_count:
+      name: "cell count"
+      device_id: device1
+    software_version:
+      name: "software version"
+      device_id: device1
+    operation_status_bitmask:
+      name: "operation status bitmask"
+      device_id: device1
+    errors_bitmask:
+      name: "errors bitmask"
+      device_id: device1
+    balancer_status_bitmask:
+      name: "balancer status bitmask"
+      device_id: device1
+    short_circuit_error_count:
+      name: "short circuit error count"
+      device_id: device1
+    charge_overcurrent_error_count:
+      name: "charge overcurrent error count"
+      device_id: device1
+    discharge_overcurrent_error_count:
+      name: "discharge overcurrent error count"
+      device_id: device1
+    cell_overvoltage_error_count:
+      name: "cell overvoltage error count"
+      device_id: device1
+    cell_undervoltage_error_count:
+      name: "cell undervoltage error count"
+      device_id: device1
+    charge_overtemperature_error_count:
+      name: "charge overtemperature error count"
+      device_id: device1
+    charge_undertemperature_error_count:
+      name: "charge undertemperature error count"
+      device_id: device1
+    discharge_overtemperature_error_count:
+      name: "discharge overtemperature error count"
+      device_id: device1
+    discharge_undertemperature_error_count:
+      name: "discharge undertemperature error count"
+      device_id: device1
+    battery_overvoltage_error_count:
+      name: "battery overvoltage error count"
+      device_id: device1
+    battery_undervoltage_error_count:
+      name: "battery undervoltage error count"
+      device_id: device1
+    cell_voltage_1:
+      name: "cell voltage 1"
+      device_id: device1
+    cell_voltage_2:
+      name: "cell voltage 2"
+      device_id: device1
+    cell_voltage_3:
+      name: "cell voltage 3"
+      device_id: device1
+    cell_voltage_4:
+      name: "cell voltage 4"
+      device_id: device1
+    temperature_1:
+      name: "temperature 1"
+      device_id: device1
+    temperature_2:
+      name: "temperature 2"
+      device_id: device1
+    temperature_3:
+      name: "temperature 3"
+      device_id: device1
 
 text_sensor:
   - platform: jbd_bms_ble


### PR DESCRIPTION
## Description

Two changes to improve the JBD BMS BLE component:

### 1. Auto-poll hardware version and error counts

Previously `JBD_CMD_HWVER` (device model) and `JBD_CMD_ERROR_COUNTS` were only fetched via buttons. This chains them after the existing `CELLINFO` response so they are fetched automatically on every poll cycle:

- `CELLINFO` response → request `HWVER`
- `HWVER` response → request `ERROR_COUNTS`

This ensures the device model text sensor and error count sensors populate without manual button presses.

### 2. Expand multi-device example config

Replaced the `# ...` placeholder comments in the sensor section of `esp32-ble-example-multiple-devices.yaml` with the full set of available sensors (current, cell voltages, temperatures, capacities, error counts, diagnostic bitmasks) for both BMS instances. This provides a complete working example for users.

## Testing

Tested with two DP04S007-L4S-150A BMS connected via BLE to an ESP32 (wemos_d1_mini32, esp-idf). Both BMS now properly report:
- Device model (auto-populated)
- All error counts (auto-populated)
- Current, charging/discharging power, cell voltages, temperatures, capacities

> [!NOTE]
> I typed the MACs into the config as I saw them in an iOS app and it failed to connect. Eventually I found I had to reverse the byte order in the config
>
> ESPHome's ble_addr_to_uint64() (esp32_ble/ble.h:41-46) treats BDA[0] as the MSB (bits 40–47), so the MAC address in secrets.yaml must match the byte order printed by the BLE scanner (A5:C2:39:2D:42:77), not standard MSB-first notation (77:42:2D:39:C2:A5). Entering the address in standard notation will cause parse_device() to always return false, resulting in persistent "Not connected" status.
